### PR TITLE
Feat(test): Add Verifier tests and improve build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
         "@rollup/plugin-json": "^6.1.0",
         "@types/chai": "^4.3.7",
         "@types/mocha": "^10.0.1",
+        "@types/sinon": "^17.0.4",
         "chai": "^4.3.7",
         "jest": "^29.6.4",
         "js-sha3": "^0.9.1",
         "mocha": "^10.2.0",
         "rollup": "^3.29.5",
         "rollup-plugin-dts": "^6.1.1",
+        "sinon": "^19.0.2",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "tslib": "^2.6.2",
@@ -74,8 +76,7 @@
         "eciesjs": "^0.4.13",
         "open-jsonrpc-provider": "^0.2.1",
         "openai": "^4.78.1",
-        "rollup-plugin-polyfill-node": "^0.13.0",
-        "sinon": "^19.0.2"
+        "rollup-plugin-polyfill-node": "^0.13.0"
     },
     "peerDependencies": {
         "@types/circomlibjs": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "packageManager": "pnpm@9.15.4",
     "browser": {},
     "scripts": {
-        "format": "prettier --write src.ts/**/*.ts src.ts/*.ts example/**/*.ts",
+        "format": "prettier --write \"src.ts/**/*.ts\"",
         "clean": "rm -rf dist lib.esm lib.commonjs types cli.commonjs",
         "build": "npm run clean && tsc -b tsconfig.commonjs.json tsconfig.types.json tsconfig.cli.json && npx rollup -c rollup.config.mjs",
         "gen-contract-type": "typechain --target ethers-v6 --node16-modules --out-dir src.ts/sdk/inference/contract/typechain '../0g-serving-broker/api/libs/0g-serving-contract/artifacts/contracts/inference/InferenceServing.sol/InferenceServing.json' && typechain --target ethers-v6 --node16-modules --out-dir src.ts/sdk/fine-tuning/contract/typechain '../0g-serving-broker/api/libs/0g-serving-contract/artifacts/contracts/fine-tuning/FineTuningServing.sol/FineTuningServing.json' && typechain --target ethers-v6 --node16-modules --out-dir src.ts/sdk/ledger/contract/typechain '../0g-serving-broker/api/libs/0g-serving-contract/artifacts/contracts/ledger/LedgerManager.sol/LedgerManager.json'",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "build": "npm run clean && tsc -b tsconfig.commonjs.json tsconfig.types.json tsconfig.cli.json && npx rollup -c rollup.config.mjs",
         "gen-contract-type": "typechain --target ethers-v6 --node16-modules --out-dir src.ts/sdk/inference/contract/typechain '../0g-serving-broker/api/libs/0g-serving-contract/artifacts/contracts/inference/InferenceServing.sol/InferenceServing.json' && typechain --target ethers-v6 --node16-modules --out-dir src.ts/sdk/fine-tuning/contract/typechain '../0g-serving-broker/api/libs/0g-serving-contract/artifacts/contracts/fine-tuning/FineTuningServing.sol/FineTuningServing.json' && typechain --target ethers-v6 --node16-modules --out-dir src.ts/sdk/ledger/contract/typechain '../0g-serving-broker/api/libs/0g-serving-contract/artifacts/contracts/ledger/LedgerManager.sol/LedgerManager.json'",
         "gen-doc": "npx typedoc --tsconfig tsconfig.esm.json",
-        "test": "mocha -r ts-node/register 'src.ts/sdk/**/*.test.ts'"
+        "test": "npm run build && mocha 'lib.commonjs/**/*.test.js'",
+        "prepare": "npm run build"
     },
     "keywords": [],
     "author": "0G Labs",

--- a/src.ts/sdk/inference/broker/__tests__/verifier.test.ts
+++ b/src.ts/sdk/inference/broker/__tests__/verifier.test.ts
@@ -1,0 +1,184 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import * as sinon from 'sinon';
+import { Verifier } from '../verifier';
+import { ethers } from 'ethers';
+
+describe('Verifier', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('verifyRA', () => {
+    it('should call NVIDIA attestation API with correct parameters', async () => {
+      // Mock fetch
+      const fetchStub = sandbox.stub(global, 'fetch');
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: async () => ({ result: true })
+      };
+      fetchStub.resolves(mockResponse as unknown as Response);
+      
+      const testPayload = { test: 'payload' };
+      const result = await Verifier.verifyRA(testPayload);
+      
+      expect(result).to.be.true;
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.equal('https://nras.attestation.nvidia.com/v3/attest/gpu');
+      
+      const requestInit = fetchStub.firstCall.args[1] as RequestInit;
+      expect(requestInit.method).to.equal('POST');
+      expect(requestInit.headers).to.deep.include({ 'Content-Type': 'application/json' });
+      
+      const requestBody = JSON.parse(requestInit.body as string);
+      expect(requestBody).to.deep.equal(testPayload);
+    });
+
+    it('should return false when API returns non-200 status', async () => {
+      const fetchStub = sandbox.stub(global, 'fetch');
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'Bad request' })
+      };
+      fetchStub.resolves(mockResponse as unknown as Response);
+      
+      const result = await Verifier.verifyRA({ test: 'payload' });
+      
+      expect(result).to.be.false;
+    });
+
+    it('should return false when fetch throws an error', async () => {
+      const fetchStub = sandbox.stub(global, 'fetch');
+      fetchStub.rejects(new Error('Network error'));
+      
+      const result = await Verifier.verifyRA({ test: 'payload' });
+      
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('verifySignature', () => {
+    it('should verify valid signatures correctly', () => {
+      // Create a real wallet for testing
+      const wallet = ethers.Wallet.createRandom();
+      const message = 'Test message';
+      const signature = wallet.signMessageSync(message);
+      
+      const result = Verifier.verifySignature(message, signature, wallet.address);
+      
+      expect(result).to.be.true;
+    });
+
+    it('should reject invalid signatures', () => {
+      // Create two different wallets
+      const wallet1 = ethers.Wallet.createRandom();
+      const wallet2 = ethers.Wallet.createRandom();
+      const message = 'Test message';
+      const signature = wallet1.signMessageSync(message);
+      
+      // Verify with wrong address
+      const result = Verifier.verifySignature(message, signature, wallet2.address);
+      
+      expect(result).to.be.false;
+    });
+
+    it('should reject tampered messages', () => {
+      const wallet = ethers.Wallet.createRandom();
+      const message = 'Original message';
+      const signature = wallet.signMessageSync(message);
+      
+      // Verify with different message
+      const result = Verifier.verifySignature('Tampered message', signature, wallet.address);
+      
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('fetSignerRA', () => {
+    it('should fetch signer RA from correct URL', async () => {
+      const fetchStub = sandbox.stub(global, 'fetch');
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          signing_address: '0x123',
+          nvidia_payload: '{"test":"data"}',
+          intel_quote: 'base64data'
+        })
+      };
+      fetchStub.resolves(mockResponse as unknown as Response);
+      
+      const url = 'https://example.com';
+      const model = 'test-model';
+      const result = await Verifier.fetSignerRA(url, model);
+      
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.equal(`${url}/v1/proxy/attestation/report?model=${model}`);
+      expect(result.signing_address).to.equal('0x123');
+      expect(result.nvidia_payload).to.deep.equal({test: 'data'});
+    });
+
+    it('should handle errors when fetching signer RA', async () => {
+      const fetchStub = sandbox.stub(global, 'fetch');
+      fetchStub.rejects(new Error('Network error'));
+      
+      try {
+        await Verifier.fetSignerRA('https://example.com', 'test-model');
+        // Should not reach here
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+      }
+    });
+  });
+
+  describe('fetSignatureByChatID', () => {
+    it('should fetch signature from correct URL', async () => {
+      const fetchStub = sandbox.stub(global, 'fetch');
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          text: 'message content',
+          signature: '0xsignature'
+        })
+      };
+      fetchStub.resolves(mockResponse as unknown as Response);
+      
+      const url = 'https://example.com';
+      const chatID = 'chat123';
+      const model = 'test-model';
+      const result = await Verifier.fetSignatureByChatID(url, chatID, model);
+      
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.equal(`${url}/v1/proxy/signature/${chatID}?model=${model}`);
+      expect(result.text).to.equal('message content');
+      expect(result.signature).to.equal('0xsignature');
+    });
+
+    it('should throw error when response is not ok', async () => {
+      const fetchStub = sandbox.stub(global, 'fetch');
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'Not found' })
+      };
+      fetchStub.resolves(mockResponse as unknown as Response);
+      
+      try {
+        await Verifier.fetSignatureByChatID('https://example.com', 'chat123', 'test-model');
+        // Should not reach here
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.equal('getting signature error');
+      }
+    });
+  });
+});


### PR DESCRIPTION
#### Added Tests
- Created unit tests for the Verifier class methods:
  - `verifyRA`: Tests for NVIDIA attestation API verification
  - `verifySignature`: Tests for signature verification with valid and invalid cases
  - `fetSignerRA`: Tests for fetching signer RA
  - `fetSignatureByChatID`: Tests for fetching signatures by chat ID

#### Build Script Improvements
- Updated test script to build before running tests:
  - Changed from `mocha -r ts-node/register 'src.ts/sdk/**/*.test.ts'` to `npm run build && mocha 'lib.commonjs/**/*.test.js'`
  - This resolves ESM/CJS compatibility issues and ensures tests run against compiled code
- Fixed format script to only target existing directories:
  - Removed references to non-existent paths (`src.ts/*.ts` and `example/**/*.ts`)
- Added prepare script to automatically build after npm install

#### Testing
All tests are passing with the updated test script. The format script now runs without errors.