### PR TITLE
fix: allow exporting of types

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "binary/dcap-qvl-web_bg.wasm"
     ],
     "exports": {
+        "types": "./types/index.d.ts",
         "require": "./lib.commonjs/index.js",
         "import": "./lib.esm/index.mjs"
     },


### PR DESCRIPTION
Types can't be read when respecting the exports of the package.json. By adding the path to the types file in the package as an export the types can be read and type inference will work as expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-serving-user-broker/40)
<!-- Reviewable:end -->
