### PR TITLE
fix: downgrade chalk to v4 to resolve ERR_REQUIRE_ESM error

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "axios": "^1.7.9",
         "brotli": "^1.3.3",
         "buffer": "^6.0.3",
-        "chalk": "^5.4.1",
+        "chalk": "4",
         "circomlibjs": "^0.1.6",
         "cli-table3": "^0.6.5",
         "commander": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       chalk:
-        specifier: ^5.4.1
-        version: 5.4.1
+        specifier: '4'
+        version: 4.1.2
       circomlibjs:
         specifier: ^0.1.6
         version: 0.1.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -1179,10 +1179,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.4.1:
-    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -4461,8 +4457,6 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  chalk@5.4.1: {}
 
   char-regex@1.0.2: {}
 


### PR DESCRIPTION
- Fixes ERR_REQUIRE_ESM error when running CLI commands
- chalk@5.4.1 is ES module only, not compatible with CommonJS require()
- chalk@4 supports both CommonJS and ES modules
- Resolves issue reported in #47 and similar compatibility problems
- Tested with Node.js 18/20/22 on macOS/Linux

Closes: #47

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-serving-user-broker/50)
<!-- Reviewable:end -->
