### PR TITLE
fix(sdk): correct processResponse JSDoc parameter order

### DIFF
--- a/src.ts/sdk/inference/broker/broker.ts
+++ b/src.ts/sdk/inference/broker/broker.ts
@@ -358,11 +358,11 @@ export class InferenceBroker {
      * with the chat ID.
      *
      * @param {string} providerAddress - The address of the provider.
-     * @param {string} content - The main content returned by the service. For example, in the case of a chatbot service,
-     * it would be the response text.
      * @param {string} chatID - Only for verifiable services. You can provide the chat ID obtained from the response to
      * automatically download the response signature. The function will verify the reliability of the response
      * using the service's signing address.
+     * @param {string} content - The main content returned by the service. For example, in the case of a chatbot service,
+     * it would be the response text.
      *
      * @returns A boolean value. True indicates the returned content is valid, otherwise it is invalid.
      *


### PR DESCRIPTION
## Summary
- Fixed incorrect JSDoc parameter order for `processResponse()` method in `InferenceBroker`
- JSDoc previously documented parameters as `(providerAddress, content, chatID)` but actual TypeScript signature is `(providerAddress, chatID?, content?)`
- This mismatch caused developer confusion when following documentation

## Details
The bug was in `src.ts/sdk/inference/broker/broker.ts` lines 360-365. The `@param` entries for `content` and `chatID` were swapped compared to the actual function signature.

| Position | Before (JSDoc) | After (JSDoc) | TypeScript Signature |
|----------|----------------|---------------|---------------------|
| 1st param | providerAddress | providerAddress | providerAddress |
| 2nd param | content | chatID | chatID? |
| 3rd param | chatID | content | content? |

## Test plan
- [ ] Verify JSDoc parameter order now matches TypeScript signature
- [ ] Rebuild documentation to confirm generated docs are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)