### PR TITLE
fix: include web-ui/out in npm package by adding web-ui/.npmignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0glabs/0g-serving-broker",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {

--- a/src.ts/cli/cli.ts
+++ b/src.ts/cli/cli.ts
@@ -15,7 +15,7 @@ export const program = new Command()
 program
     .name('0g-compute-cli')
     .description('CLI for interacting with ZG Compute Network')
-    .version('0.7.0')
+    .version('0.7.1')
 
 ledger(program)
 

--- a/web-ui/.npmignore
+++ b/web-ui/.npmignore
@@ -1,0 +1,13 @@
+# Override .gitignore for npm packaging
+# The out/ directory must be included in the published package
+# (web-ui/.gitignore excludes out/ which prevents npm from packing it)
+
+node_modules/
+.next/
+src/
+public/
+.env
+.env.*
+*.tsbuildinfo
+next-env.d.ts
+.vercel

--- a/web-ui/pnpm-lock.yaml
+++ b/web-ui/pnpm-lock.yaml
@@ -3604,7 +3604,7 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}


### PR DESCRIPTION
web-ui/.gitignore excludes out/ which caused npm to omit the built web UI static files from the published package. Adding .npmignore in web-ui/ overrides .gitignore for npm packing, ensuring the web UI is included.