### PR TITLE
feat(ledger): support retrieve-fund from specific provider

### DIFF
--- a/src.ts/cli/ledger.ts
+++ b/src.ts/cli/ledger.ts
@@ -143,6 +143,10 @@ export default function ledger(program: Command) {
         .option('--inference-ca <address>', 'Inference contract address')
         .option('--fine-tuning-ca <address>', 'Fine Tuning contract address')
         .option('--service <type>', 'Service type: inference or fine-tuning')
+        .option(
+            '--provider <address>',
+            'Provider address to retrieve funds from (if not specified, shows interactive selection)'
+        )
         .option('--gas-price <price>', 'Gas price for transactions')
         .option('--max-gas-price <price>', 'Max gas price for transactions')
         .option('--step <step>', 'Step for gas price calculation')
@@ -150,11 +154,61 @@ export default function ledger(program: Command) {
             const serviceType = await selectServiceType(options)
 
             withBroker(options, async (broker) => {
-                console.log(
-                    `Retrieving funds from ${serviceType} sub accounts...`
-                )
-                await broker.ledger.retrieveFund(serviceType)
-                console.log(`Funds retrieved from ${serviceType} sub accounts`)
+                let selectedProvider: string | undefined = options.provider
+
+                if (!selectedProvider) {
+                    // Get providers with balance for interactive selection
+                    const providers =
+                        await broker.ledger.getProvidersWithBalance(serviceType)
+
+                    if (!providers || providers.length === 0) {
+                        console.log(
+                            chalk.yellow(
+                                `No providers with balance found for ${serviceType}.`
+                            )
+                        )
+                        return
+                    }
+
+                    const providerOptions = [
+                        {
+                            title: 'All providers',
+                            value: 'all',
+                            description: `Retrieve funds from all ${providers.length} provider(s)`,
+                        },
+                        ...providers.map(([address, balance, pendingRefund]) => ({
+                            title: address,
+                            value: address,
+                            description: `Balance: ${neuronToA0gi(balance).toFixed(6)} 0G, Pending refund: ${neuronToA0gi(pendingRefund).toFixed(6)} 0G`,
+                        })),
+                    ]
+
+                    selectedProvider = await interactiveSelect({
+                        message: `Select provider to retrieve funds from (${serviceType}):`,
+                        options: providerOptions,
+                    })
+                }
+
+                if (selectedProvider === 'all') {
+                    console.log(
+                        `Retrieving funds from all ${serviceType} sub accounts...`
+                    )
+                    await broker.ledger.retrieveFund(serviceType)
+                    console.log(
+                        `Funds retrieved from all ${serviceType} sub accounts`
+                    )
+                } else {
+                    console.log(
+                        `Retrieving funds from ${serviceType} sub account for provider ${selectedProvider}...`
+                    )
+                    await broker.ledger.retrieveFundFromProvider(
+                        serviceType,
+                        selectedProvider
+                    )
+                    console.log(
+                        `Funds retrieved from ${serviceType} sub account for provider ${selectedProvider}`
+                    )
+                }
 
                 // Add helpful information about checking lock time
                 console.log(

--- a/src.ts/sdk/ledger/broker.ts
+++ b/src.ts/sdk/ledger/broker.ts
@@ -250,7 +250,24 @@ export class LedgerBroker {
     }
 
     /**
-     * Retrieves funds from the all sub-accounts (for inference and fine-tuning) of the current wallet address.
+     * Returns the list of providers with non-zero balance or pending refund for a given service type.
+     *
+     * @param serviceTypeStr - The type of service. It can be either 'inference' or 'fine-tuning'.
+     * @returns A promise that resolves to an array of [providerAddress, balance, pendingRefund] tuples.
+     * @throws Will throw an error if the retrieval fails.
+     */
+    public getProvidersWithBalance = async (
+        serviceTypeStr: 'inference' | 'fine-tuning'
+    ): Promise<[string, bigint, bigint][]> => {
+        try {
+            return await this.ledger.getProvidersWithBalance(serviceTypeStr)
+        } catch (error) {
+            throwFormattedError(error)
+        }
+    }
+
+    /**
+     * Retrieves funds from all sub-accounts (for inference and fine-tuning) of the current wallet address.
      *
      * @param serviceTypeStr - The type of service for which the funds are being retrieved.
      *                         It can be either 'inference' or 'fine-tuning'.
@@ -266,6 +283,33 @@ export class LedgerBroker {
     ) => {
         try {
             return await this.ledger.retrieveFund(serviceTypeStr, gasPrice)
+        } catch (error) {
+            throwFormattedError(error)
+        }
+    }
+
+    /**
+     * Retrieves funds from a specific provider's sub-account.
+     *
+     * @param serviceTypeStr - The type of service. It can be either 'inference' or 'fine-tuning'.
+     * @param providerAddress - The address of the provider to retrieve funds from.
+     * @param {number} gasPrice - The gas price to be used for the transaction. If not provided,
+     *                            the default/auto-generated gas price will be used. Units are in neuron.
+     *
+     * @returns A promise that resolves with the result of the fund retrieval operation.
+     * @throws Will throw an error if the fund retrieval operation fails.
+     */
+    public retrieveFundFromProvider = async (
+        serviceTypeStr: 'inference' | 'fine-tuning',
+        providerAddress: string,
+        gasPrice?: number
+    ) => {
+        try {
+            return await this.ledger.retrieveFundFromProvider(
+                serviceTypeStr,
+                providerAddress,
+                gasPrice
+            )
         } catch (error) {
             throwFormattedError(error)
         }

--- a/src.ts/sdk/ledger/ledger.ts
+++ b/src.ts/sdk/ledger/ledger.ts
@@ -223,6 +223,30 @@ export class LedgerProcessor {
         }
     }
 
+    /**
+     * Returns the list of providers with their balance info for a given service type.
+     *
+     * @param serviceTypeStr - 'inference' or 'fine-tuning'
+     * @returns Array of [providerAddress, balance, pendingRefund] tuples
+     */
+    async getProvidersWithBalance(
+        serviceTypeStr: 'inference' | 'fine-tuning'
+    ): Promise<[string, bigint, bigint][]> {
+        try {
+            const ledger = await this.getLedgerWithDetail()
+            const providers =
+                serviceTypeStr === 'inference' ? ledger.infers : ledger.fines
+            if (!providers) {
+                throw new Error(
+                    'No providers found, please ensure you are using Wallet instance to create the broker'
+                )
+            }
+            return providers.filter((x) => x[1] > 0n || x[2] > 0n)
+        } catch (error) {
+            throwFormattedError(error)
+        }
+    }
+
     async retrieveFund(
         serviceTypeStr: 'inference' | 'fine-tuning',
         gasPrice?: number
@@ -260,6 +284,49 @@ export class LedgerProcessor {
             )
 
             if (serviceTypeStr == 'inference') {
+                await this.cache.setItem(
+                    CACHE_KEYS.FIRST_ROUND,
+                    'true',
+                    10000000 * 60 * 1000,
+                    CacheValueTypeEnum.Other
+                )
+            }
+        } catch (error) {
+            throwFormattedError(error)
+        }
+    }
+
+    /**
+     * Retrieves funds from a specific provider's sub-account.
+     *
+     * @param serviceTypeStr - 'inference' or 'fine-tuning'
+     * @param providerAddress - The address of the provider to retrieve funds from
+     * @param gasPrice - Optional gas price for the transaction
+     */
+    async retrieveFundFromProvider(
+        serviceTypeStr: 'inference' | 'fine-tuning',
+        providerAddress: string,
+        gasPrice?: number
+    ) {
+        try {
+            const serviceName =
+                serviceTypeStr === 'inference'
+                    ? this.serviceNames.inference
+                    : this.serviceNames.fineTuning
+
+            if (!serviceName) {
+                throw new Error(
+                    `Service name not available for ${serviceTypeStr}`
+                )
+            }
+
+            await this.ledgerContract.retrieveFund(
+                [providerAddress],
+                serviceName,
+                gasPrice
+            )
+
+            if (serviceTypeStr === 'inference') {
                 await this.cache.setItem(
                     CACHE_KEYS.FIRST_ROUND,
                     'true',


### PR DESCRIPTION
Add --provider option to retrieve-fund CLI command with interactive provider selection when not specified. Adds SDK methods getProvidersWithBalance and retrieveFundFromProvider to support per-provider fund retrieval.