### PR TITLE
fix: docs corrections and dead code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Access decentralized AI computing through the 0G Compute Network - a GPU marketp
 
 ## Requirements
 
-- Node.js >= 22.0.0
+- Node.js >= 20.0.0
 - A wallet with 0G tokens
 
 ## Installation

--- a/src.ts/sdk/inference/broker/broker.ts
+++ b/src.ts/sdk/inference/broker/broker.ts
@@ -304,14 +304,12 @@ export class InferenceBroker extends ReadOnlyInferenceBroker {
      *
      * @example
      *
-     * const { endpoint, model } = await broker.getServiceMetadata(
+     * const { endpoint, model } = await broker.inference.getServiceMetadata(
      *   providerAddress,
-     *   serviceName,
      * );
      *
-     * const headers = await broker.getServiceMetadata(
+     * const headers = await broker.inference.getRequestHeaders(
      *   providerAddress,
-     *   serviceName,
      *   content,
      * );
      *
@@ -322,12 +320,10 @@ export class InferenceBroker extends ReadOnlyInferenceBroker {
      *
      * const completion = await openai.chat.completions.create(
      *   {
-     *     messages: [{ role: "system", content }],
+     *     messages: [{ role: "user", content }],
      *     model,
      *   },
-     *   headers: {
-     *     ...headers,
-     *   },
+     *   { headers: { ...headers } },
      * );
      *
      * @throws An error if errors occur during the processing of the request.

--- a/src.ts/sdk/inference/broker/request.ts
+++ b/src.ts/sdk/inference/broker/request.ts
@@ -4,7 +4,7 @@ import type { InferenceServingContract } from '../contract'
 import type { LedgerBroker } from '../../ledger'
 import { Automata } from '../../common/automata'
 import { throwFormattedError } from '../../common/utils'
-// import { Verifier } from './verifier'
+
 
 /**
  * ServingRequestHeaders contains headers related to request.

--- a/src.ts/sdk/inference/broker/response.ts
+++ b/src.ts/sdk/inference/broker/response.ts
@@ -42,21 +42,17 @@ export class ResponseProcessor extends ZGServingUserBrokerBase {
 
             const svc = await extractor.getSvcInfo()
             if (!isVerifiability(svc.verifiability)) {
-                console.warn('this service is not verifiable')
+                logger.warn('this service is not verifiable')
                 return false
             }
 
             if (!svc.teeSignerAcknowledged) {
-                console.warn('TEE Signer is not acknowledged')
+                logger.warn('TEE Signer is not acknowledged')
                 return false
             }
 
-            if (!chatID) {
-                throw new Error('Chat ID does not exist')
-            }
-
             if (!svc.additionalInfo) {
-                console.warn('Service additionalInfo does not exist')
+                logger.warn('Service additionalInfo does not exist')
                 return false
             }
 


### PR DESCRIPTION
## Summary

Small fixes found during SDK audit — all verified against source code.

## Changes

### 1. README: Node.js version mismatch
- README said `>= 22.0.0`, package.json says `>= 20.0.0`, CI tests both 20.x and 22.x
- Fixed to `>= 20.0.0`

### 2. `getRequestHeaders` JSDoc example (broker.ts)
The `@example` had two bugs:
- Called `getServiceMetadata` instead of `getRequestHeaders` for the headers call
- Passed non-existent `serviceName` parameter

```diff
- const headers = await broker.getServiceMetadata(providerAddress, serviceName, content);
+ const headers = await broker.inference.getRequestHeaders(providerAddress, content);
```

Also fixed `role: "system"` → `role: "user"` and headers placement in the OpenAI SDK call.

### 3. Dead code in response.ts
Duplicate `if (!chatID)` check — line 38 already returns `null`, so the second check at line 54 was unreachable:

```diff
- if (!chatID) {
-     throw new Error('Chat ID does not exist')
- }
```

Also replaced 3 `console.warn` calls with the existing `logger.warn` import (per CLAUDE.md SDK rules).

### 4. Commented-out import in request.ts
Removed `// import { Verifier } from './verifier'`

## Verification

All changes verified against actual TypeScript signatures before committing. No behavioral changes — only docs and dead code removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)