### PR TITLE
feat(web-ui): detect and warn about API keys from other origins

### DIFF
--- a/web-ui/src/app/wallet/components/SlotManager.tsx
+++ b/web-ui/src/app/wallet/components/SlotManager.tsx
@@ -54,6 +54,7 @@ export function SlotManager({
   // Separate slots by status
   const activeSlots = allSlots.filter((s) => s.status === "active")
   const revokedSlots = allSlots.filter((s) => s.status === "revoked" && s.id !== 255)
+  const unknownSlots = allSlots.filter((s) => s.status === "unknown")
   const availableSlots = allSlots.filter((s) => s.status === "available")
 
   const handleRevoke = async (slot: Slot) => {
@@ -186,6 +187,7 @@ export function SlotManager({
           <p className="text-xs text-gray-500 mt-1">
             {slotStats.active + slotStats.revoked} / {slotStats.total} slots used •{" "}
             {slotStats.available} available
+            {slotStats.unknown > 0 && ` • ${slotStats.unknown} unknown`}
           </p>
         </div>
         <div className="flex gap-2">
@@ -237,11 +239,17 @@ export function SlotManager({
           </div>
 
           {/* Legend */}
-          <div className="flex items-center gap-4 text-xs">
+          <div className="flex items-center gap-4 text-xs flex-wrap">
             <div className="flex items-center gap-1">
               <div className="w-3 h-3 rounded-full bg-green-500" />
               <span className="text-gray-600">Active: {slotStats.active}</span>
             </div>
+            {slotStats.unknown > 0 && (
+              <div className="flex items-center gap-1">
+                <div className="w-3 h-3 rounded-full bg-amber-400" />
+                <span className="text-amber-600">Unknown: {slotStats.unknown}</span>
+              </div>
+            )}
             <div className="flex items-center gap-1">
               <div className="w-3 h-3 rounded-full bg-gray-600" />
               <span className="text-gray-600">Revoked: {slotStats.revoked}</span>
@@ -338,6 +346,23 @@ export function SlotManager({
         </div>
       )}
 
+      {/* Unknown Slots Warning */}
+      {unknownSlots.length > 0 && (
+        <Alert className="bg-amber-50 border-amber-200">
+          <AlertTriangle className="h-4 w-4 text-amber-600" />
+          <AlertDescription className="text-xs text-amber-800">
+            <p className="font-medium mb-1">
+              {unknownSlots.length} slot{unknownSlots.length > 1 ? 's' : ''} may have keys from another device or browser
+            </p>
+            <p>
+              These slots are not revoked and have no locally stored keys. They may have been
+              created from a different browser origin. Generating a new key could reuse one of
+              these slots and invalidate the original key.
+            </p>
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Revoked Slots (Collapsible) */}
       {revokedSlots.length > 0 && (
         <div className="space-y-2">
@@ -388,12 +413,14 @@ export function SlotManager({
             <div className="grid grid-cols-16 gap-1">
               {allSlots.map((slot) => {
                 const icon =
-                  slot.status === "active" ? "🟢" : slot.status === "revoked" ? "⚫" : "⚪"
+                  slot.status === "active" ? "🟢" : slot.status === "revoked" ? "⚫" : slot.status === "unknown" ? "🟡" : "⚪"
                 const title =
                   slot.status === "active"
                     ? `Slot #${slot.id}: ${slot.keyLabel || "Active"}`
                     : slot.status === "revoked"
                     ? `Slot #${slot.id}: Revoked`
+                    : slot.status === "unknown"
+                    ? `Slot #${slot.id}: Unknown (possible external key)`
                     : `Slot #${slot.id}: Available`
 
                 return (
@@ -409,7 +436,8 @@ export function SlotManager({
             </div>
             <div className="mt-3 text-xs text-gray-500 space-y-1">
               <p>🟢 = Active key (hover to see details)</p>
-              <p>⚫ = Revoked slot (can't reuse)</p>
+              <p>🟡 = Unknown (possible key from another device/browser)</p>
+              <p>⚫ = Revoked slot (can&apos;t reuse)</p>
               <p>⚪ = Available slot</p>
             </div>
           </Card>

--- a/web-ui/src/app/wallet/components/SlotStatusCompact.tsx
+++ b/web-ui/src/app/wallet/components/SlotStatusCompact.tsx
@@ -152,6 +152,15 @@ export function SlotStatusCompact({ provider, refreshTrigger }: SlotStatusCompac
             <span className="inline-block w-2 h-2 rounded-full bg-gray-400" title="Available"></span>
             <span className="text-gray-600">{slotStats.available} available</span>
           </div>
+          {slotStats.unknown > 0 && (
+            <>
+              <span className="text-gray-300">•</span>
+              <div className="flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-full bg-amber-400" title="Possible external keys"></span>
+                <span className="text-amber-600">{slotStats.unknown} unknown</span>
+              </div>
+            </>
+          )}
           {slotStats.revoked > 0 && (
             <>
               <span className="text-gray-300">•</span>

--- a/web-ui/src/shared/components/provider-setup/ProviderApiKeyManager.tsx
+++ b/web-ui/src/shared/components/provider-setup/ProviderApiKeyManager.tsx
@@ -30,6 +30,7 @@ import {
   Copy,
   CheckCircle2,
   AlertCircle,
+  AlertTriangle,
   Eye,
   EyeOff,
   Trash2,
@@ -103,7 +104,13 @@ export function ProviderApiKeyManager({
   const [deletingKeyId, setDeletingKeyId] = useState<string | null>(null)
 
   const { getSecret, revokeToken } = useBrokerOperations()
-  const { findNextAvailableTokenIdFromData, refresh: refreshSlots } = useSlotStatus(provider, address)
+  const { slotStats, findNextAvailableTokenIdFromData, refresh: refreshSlots } = useSlotStatus(provider, address)
+
+  // Detect potential external keys (generated from another origin/device)
+  const possibleExternalKeys = React.useMemo(() => {
+    if (!address) return 0
+    return slotStats.unknown
+  }, [address, slotStats.unknown])
 
   // Check if user already has keys for this provider (reactive)
   const [existingKeys, setExistingKeys] = useState<StoredApiKey[]>(() =>
@@ -130,6 +137,21 @@ export function ProviderApiKeyManager({
     setIsGenerating(true)
     setError(null)
     setGeneratedKey(null)
+
+    // Warn if there may be keys from another origin
+    if (possibleExternalKeys > 0 && existingKeys.length === 0) {
+      const proceed = confirm(
+        'Your on-chain account shows previous key activity, but no keys are stored ' +
+        'in this browser.\n\n' +
+        'Generating a new key may reuse a slot that has an active key from ' +
+        'another device or browser, which would invalidate that key.\n\n' +
+        'Continue?'
+      )
+      if (!proceed) {
+        setIsGenerating(false)
+        return
+      }
+    }
 
     // FIXED: Add retry logic to handle race conditions when multiple tabs generate keys simultaneously
     const MAX_RETRIES = 3
@@ -461,6 +483,25 @@ export function ProviderApiKeyManager({
             true
           )}
         </div>
+      )}
+
+      {/* External Keys Warning */}
+      {possibleExternalKeys > 0 && existingKeys.length === 0 && (
+        <Alert className="bg-amber-50 border-amber-200">
+          <AlertTriangle className="h-4 w-4 text-amber-600" />
+          <AlertDescription className="text-xs text-amber-800">
+            <p className="font-medium mb-1">Keys may exist from another device or browser</p>
+            <p>
+              Your on-chain account shows previous activity (generation: {slotStats.generation}),
+              but no API keys are stored in this browser. Keys generated from another
+              origin are not visible here. You can:
+            </p>
+            <ul className="list-disc list-inside mt-1 space-y-0.5">
+              <li>Generate a new key (uses a new slot)</li>
+              <li>Use &quot;Refresh All Slots&quot; to revoke everything and start fresh</li>
+            </ul>
+          </AlertDescription>
+        </Alert>
       )}
 
       {/* Generate New Key Section */}

--- a/web-ui/src/shared/hooks/useOnChainTokens.ts
+++ b/web-ui/src/shared/hooks/useOnChainTokens.ts
@@ -49,6 +49,9 @@ export interface UseOnChainTokensReturn {
   /** Generation counter from contract */
   generation: number
 
+  /** Count of non-revoked slots with no localStorage data (potential external keys) */
+  externalSlotCount: number
+
   /** Is fetching from contract */
   isLoading: boolean
 
@@ -71,6 +74,7 @@ export function useOnChainTokens(provider: string, userAddress?: string): UseOnC
   const { broker } = useBroker()
   const [tokens, setTokens] = useState<OnChainToken[]>([])
   const [generation, setGeneration] = useState<number>(0)
+  const [externalSlotCount, setExternalSlotCount] = useState<number>(0)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -146,6 +150,14 @@ export function useOnChainTokens(provider: string, userAddress?: string): UseOnC
         })
       }
 
+      // Count slots that may have keys from other origins
+      // Heuristic: non-revoked, no localData, AND user has interacted (gen > 0 or has some local keys)
+      const hasInteracted = gen > 0 || localKeys.length > 0
+      const possibleExternalSlots = hasInteracted
+        ? tokenList.filter(t => !t.isRevoked && !t.localData).length
+        : 0
+      setExternalSlotCount(possibleExternalSlots)
+
       setTokens(tokenList)
       console.log('📡 [fetchTokenStatus] Fetched tokens, returning data...')
       console.log('📡 [fetchTokenStatus] Total tokens:', tokenList.length)
@@ -173,6 +185,7 @@ export function useOnChainTokens(provider: string, userAddress?: string): UseOnC
   return {
     tokens,
     generation,
+    externalSlotCount,
     isLoading,
     error,
     refresh: fetchTokenStatus,

--- a/web-ui/src/shared/hooks/useSlotStatus.ts
+++ b/web-ui/src/shared/hooks/useSlotStatus.ts
@@ -23,7 +23,7 @@ import { useMemo, useCallback } from 'react'
 import { useOnChainTokens, type OnChainToken } from './useOnChainTokens'
 import { getApiKeysForProvider, type StoredApiKey } from '../utils/apiKeyStorage'
 
-export type SlotStatus = 'available' | 'active' | 'revoked'
+export type SlotStatus = 'available' | 'active' | 'revoked' | 'unknown'
 
 export interface Slot {
   /** Slot number (0-255) */
@@ -54,6 +54,9 @@ export interface SlotStats {
 
   /** Available slots ready for use */
   available: number
+
+  /** Slots that may have keys from another origin/device */
+  unknown: number
 
   /** Percentage of used slots (active + revoked) */
   usagePercent: number
@@ -95,7 +98,7 @@ const MAX_TOKEN_ID = 254 // Slots 0-254 are usable (slot 255 reserved for epheme
  * @param userAddress - User's wallet address for localStorage lookup (optional)
  */
 export function useSlotStatus(provider: string, userAddress?: string): UseSlotStatusReturn {
-  const { tokens, generation, isLoading, error, refresh } = useOnChainTokens(provider, userAddress)
+  const { tokens, generation, externalSlotCount, isLoading, error, refresh } = useOnChainTokens(provider, userAddress)
 
   /**
    * Calculate slot statistics and build detailed slot list
@@ -103,7 +106,12 @@ export function useSlotStatus(provider: string, userAddress?: string): UseSlotSt
   const { slotStats, allSlots } = useMemo(() => {
     let activeCount = 0
     let revokedCount = 0
+    let unknownCount = 0
     const slots: Slot[] = []
+
+    // Determine if user has interacted with the key system before
+    const localKeyCount = tokens.filter(t => t.localData).length
+    const hasInteracted = generation > 0 || localKeyCount > 0
 
     // Process slots 0-254 (usable slots)
     for (let i = 0; i <= MAX_TOKEN_ID; i++) {
@@ -135,11 +143,16 @@ export function useSlotStatus(provider: string, userAddress?: string): UseSlotSt
           keyLabel: token.localData.label,
           keyData: token.localData,
         })
+      } else if (hasInteracted) {
+        // Not revoked, no local data, but user has interacted before.
+        // This slot may have a key from another origin/device.
+        unknownCount++
+        slots.push({
+          id: i,
+          status: 'unknown',
+        })
       } else {
-        // Not revoked but no local data - could be:
-        // 1. Never used (available)
-        // 2. Used but localStorage lost (unknown)
-        // For slot visualization, we treat it as available unless we know it's occupied
+        // Not revoked, no local data, brand new user — truly available
         slots.push({
           id: i,
           status: 'available',
@@ -153,7 +166,7 @@ export function useSlotStatus(provider: string, userAddress?: string): UseSlotSt
       status: 'revoked', // Always show as unavailable since it's reserved
     })
 
-    const availableCount = TOTAL_SLOTS - activeCount - revokedCount
+    const availableCount = TOTAL_SLOTS - activeCount - revokedCount - unknownCount
     const usagePercent = Math.round(((activeCount + revokedCount) / TOTAL_SLOTS) * 100)
 
     const stats: SlotStats = {
@@ -161,6 +174,7 @@ export function useSlotStatus(provider: string, userAddress?: string): UseSlotSt
       active: activeCount,
       revoked: revokedCount,
       available: availableCount,
+      unknown: unknownCount,
       usagePercent,
       generation,
     }


### PR DESCRIPTION
## Summary

- Added detection heuristic for API keys that may exist from another browser origin/device
- Added "unknown" slot status type for ambiguous slots (not revoked, no localStorage data, but user has previous activity)
- Added amber warning banner when external keys are detected
- Added confirm dialog before key generation when slot collision is possible
- Added unknown slot visualization (yellow circle) in slot grid

## Why

API key strings are stored in origin-scoped `localStorage`, while token slots are tracked on-chain. When a user generates keys from one origin (e.g., `localhost:3090`) and later accesses the WebUI from a different origin, those slots appear as "available" instead of showing a warning. This can lead to silent key invalidation when the user generates a new key that reuses an occupied slot.

## Files changed

| File | Change |
|------|--------|
| `useOnChainTokens.ts` | Added `externalSlotCount` return value using generation counter heuristic |
| `useSlotStatus.ts` | Added `'unknown'` slot status type and `unknown` count to SlotStats |
| `ProviderApiKeyManager.tsx` | Added amber warning banner + confirm dialog before generation |
| `SlotStatusCompact.tsx` | Added "unknown" count in compact header |
| `SlotManager.tsx` | Added yellow circle icon, legend entry, and warning alert for unknown slots |

## How the heuristic works

A slot is marked "unknown" (instead of "available") when ALL of these are true:
1. The slot is **not revoked** on-chain
2. There is **no localStorage data** for this slot
3. The user **has interacted before** (generation counter > 0 OR has at least one local key)

This prevents false positives for brand-new users (generation === 0, no keys) while catching the case where keys exist from another origin.

## Edge cases handled

- **Brand-new user**: No warning (generation === 0, no local keys → all slots truly available)
- **All slots from another origin**: Warning banner + confirm dialog
- **Mixed slots**: Unknown count shown alongside active count
- **Cleared localStorage**: Same behavior as "another origin" — warning appears
- **Revoked slots**: Handled correctly by on-chain bitmap, no change needed

## Test plan

- [ ] New user (no keys, generation=0): No warning, all slots available
- [ ] Generate key on Origin A, view from Origin B: Warning banner visible, unknown slots in grid
- [ ] Generate key with warning: Confirm dialog appears, can proceed or cancel
- [ ] "Refresh All" clears warning (generation increments, bitmap resets)
- [ ] Slot grid shows yellow circles for unknown slots with correct tooltip

Fixes #174