### PR TITLE
fix(web-ui): wire addTransaction into wallet fund flows and fix explorer URL

### DIFF
--- a/web-ui/src/app/wallet/components/AddFundsForm.tsx
+++ b/web-ui/src/app/wallet/components/AddFundsForm.tsx
@@ -18,7 +18,7 @@ const PRESET_AMOUNTS = [
 
 interface AddFundsFormProps {
     depositFund: (amount: number) => Promise<void>
-    onSuccess?: () => void
+    onSuccess?: (amount: number) => void
 }
 
 export function AddFundsForm({ depositFund, onSuccess }: AddFundsFormProps) {
@@ -56,7 +56,7 @@ export function AddFundsForm({ depositFund, onSuccess }: AddFundsFormProps) {
                 description: `Added ${amount} 0G tokens to your account.`,
             })
             setAmount('')
-            onSuccess?.()
+            onSuccess?.(numAmount)
         } catch (err: unknown) {
             const errorMessage = err instanceof Error ? err.message : 'Failed to add funds'
             setError(errorMessage)

--- a/web-ui/src/app/wallet/components/TransactionHistory.tsx
+++ b/web-ui/src/app/wallet/components/TransactionHistory.tsx
@@ -380,12 +380,19 @@ export function TransactionHistory({
 }
 
 // Hook to manage transaction history (can be expanded to fetch from blockchain/backend)
-export function useTransactionHistory() {
+export function useTransactionHistory(walletAddress?: string) {
     const [transactions, setTransactions] = useState<Transaction[]>([])
     const [isLoading, setIsLoading] = useState(false)
 
+    // Scope localStorage key by wallet address to prevent cross-wallet data mixing
+    const storageKey = walletAddress
+        ? `0g_tx_history_${walletAddress.toLowerCase()}`
+        : null
+
     // Add a new transaction
     const addTransaction = (transaction: Omit<Transaction, 'id' | 'timestamp'>) => {
+        if (!storageKey) return
+
         const newTx: Transaction = {
             ...transaction,
             id: `tx-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
@@ -395,70 +402,49 @@ export function useTransactionHistory() {
 
         // Persist to localStorage
         try {
-            const stored = localStorage.getItem('transactionHistory')
+            const stored = localStorage.getItem(storageKey)
             const existing = stored ? JSON.parse(stored) : []
-            localStorage.setItem('transactionHistory', JSON.stringify([newTx, ...existing].slice(0, 100)))
+            localStorage.setItem(storageKey, JSON.stringify([newTx, ...existing].slice(0, 100)))
         } catch {
             // Silent fail for localStorage
         }
     }
 
     // Load transactions from localStorage
-    const loadTransactions = () => {
+    const loadTransactions = React.useCallback(() => {
+        if (!storageKey) {
+            setTransactions([])
+            return
+        }
         setIsLoading(true)
         try {
-            const stored = localStorage.getItem('transactionHistory')
+            const stored = localStorage.getItem(storageKey)
             if (stored) {
                 setTransactions(JSON.parse(stored))
+            } else {
+                setTransactions([])
             }
         } catch {
             // Silent fail
         } finally {
             setIsLoading(false)
         }
-    }
+    }, [storageKey])
 
     // Refresh transactions
     const refreshTransactions = () => {
         loadTransactions()
     }
 
-    // Update transaction status
-    const updateTransactionStatus = (txId: string, status: Transaction['status'], txHash?: string) => {
-        setTransactions(prev => prev.map(tx => {
-            if (tx.id === txId) {
-                return { ...tx, status, ...(txHash ? { txHash } : {}) }
-            }
-            return tx
-        }))
-
-        // Update in localStorage
-        try {
-            const stored = localStorage.getItem('transactionHistory')
-            if (stored) {
-                const existing = JSON.parse(stored)
-                const updated = existing.map((tx: Transaction) => {
-                    if (tx.id === txId) {
-                        return { ...tx, status, ...(txHash ? { txHash } : {}) }
-                    }
-                    return tx
-                })
-                localStorage.setItem('transactionHistory', JSON.stringify(updated))
-            }
-        } catch {
-            // Silent fail
-        }
-    }
-
+    // Reload when wallet address changes
     React.useEffect(() => {
         loadTransactions()
-    }, [])
+    }, [loadTransactions])
 
     return {
         transactions,
         isLoading,
         addTransaction,
         refreshTransactions,
-        updateTransactionStatus,
     }
 }

--- a/web-ui/src/app/wallet/components/WithdrawDialog.tsx
+++ b/web-ui/src/app/wallet/components/WithdrawDialog.tsx
@@ -23,7 +23,7 @@ interface WithdrawDialogProps {
     totalBalance: string
     lockedBalance: string
     refund: (amount: number) => Promise<void>
-    onSuccess?: () => void
+    onSuccess?: (amount: number) => void
     onDeleteSuccess?: () => void
 }
 
@@ -85,7 +85,7 @@ export function WithdrawDialog({
                 title: "Withdrawal Successful",
                 description: `Successfully withdrew ${formatNumber(amount.toString())} 0G to your wallet.`,
             })
-            onSuccess?.()
+            onSuccess?.(amount)
         } catch (err: unknown) {
             const errorMessage = err instanceof Error ? err.message : 'Failed to withdraw'
             setError(errorMessage)

--- a/web-ui/src/app/wallet/page.tsx
+++ b/web-ui/src/app/wallet/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useEffect, Suspense } from "react";
-import { useAccount } from 'wagmi';
+import React, { useState, useEffect, useMemo, Suspense } from "react";
+import { useAccount, useChainId } from 'wagmi';
 import { useBroker } from '@/shared/providers/BrokerProvider';
 import { useSearchParams } from 'next/navigation';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -11,9 +11,11 @@ import { TransactionHistory, useTransactionHistory } from './components/Transact
 import { Loader2 } from 'lucide-react';
 import { formatNumber } from '@/shared/utils/formatNumber';
 import { useToast } from '@/hooks/use-toast';
+import { zgMainnet, zgTestnet } from '@/shared/config/wagmi';
 
 function LedgerContent() {
-  const { isConnected } = useAccount();
+  const { isConnected, address } = useAccount();
+  const chainId = useChainId();
   const searchParams = useSearchParams();
   const {
     broker,
@@ -25,7 +27,14 @@ function LedgerContent() {
 
   const [activeTab, setActiveTab] = useState<'overview' | 'detail' | 'history'>('overview');
   const [expandedRefunds, setExpandedRefunds] = useState<{ [key: string]: boolean }>({});
-  const { transactions, isLoading: txLoading, refreshTransactions, addTransaction } = useTransactionHistory();
+  const { transactions, isLoading: txLoading, refreshTransactions, addTransaction } = useTransactionHistory(address);
+
+  // Derive explorer URL from connected chain config
+  const explorerBaseUrl = useMemo(() => {
+    const chain = chainId === zgTestnet.id ? zgTestnet : zgMainnet;
+    const url = chain.blockExplorers?.default?.url ?? 'https://chainscan.0g.ai/';
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+  }, [chainId]);
   const [refundDetails, setRefundDetails] = useState<{ [key: string]: { amount: bigint, remainTime: bigint }[] }>({});
   const [loadingRefunds, setLoadingRefunds] = useState<{ [key: string]: boolean }>({});
   const [isRetrieving, setIsRetrieving] = useState<{ [key: string]: boolean }>({});
@@ -125,6 +134,12 @@ function LedgerContent() {
         title: 'Retrieve Requested',
         description: 'All provider fund retrieval has been requested. Please wait for the lock period. Check the Distributed Provider Funds details section for wait times.',
       });
+      addTransaction({
+        type: 'retrieve',
+        amount: '0',
+        status: 'completed',
+        description: 'Requested retrieval of all provider funds (inference + fine-tuning)',
+      });
       await refreshLedgerInfo().catch(() => {});
     } catch (err: unknown) {
       toast({
@@ -146,6 +161,12 @@ function LedgerContent() {
         title: 'Retrieve Requested',
         description: 'Inference funds retrieve request submitted.',
       });
+      addTransaction({
+        type: 'retrieve',
+        amount: '0',
+        status: 'completed',
+        description: 'Inference funds retrieve request submitted',
+      });
       await refreshLedgerInfo().catch(() => {});
     } catch (err: unknown) {
       toast({
@@ -166,6 +187,12 @@ function LedgerContent() {
       toast({
         title: 'Retrieve Requested',
         description: 'Fine-tuning funds retrieve request submitted.',
+      });
+      addTransaction({
+        type: 'retrieve',
+        amount: '0',
+        status: 'completed',
+        description: 'Fine-tuning funds retrieve request submitted',
       });
       await refreshLedgerInfo().catch(() => {});
     } catch (err: unknown) {
@@ -190,6 +217,13 @@ function LedgerContent() {
       toast({
         title: 'Retrieve Requested',
         description: `Retrieve request submitted for provider ${shortAddr}.`,
+      });
+      addTransaction({
+        type: 'retrieve',
+        amount: '0',
+        status: 'completed',
+        providerAddress,
+        description: `Retrieve request submitted for ${type} provider ${shortAddr}`,
       });
       await refreshLedgerInfo().catch(() => {});
     } catch (err: unknown) {
@@ -270,7 +304,15 @@ function LedgerContent() {
               {/* Add Funds Section - Now self-contained */}
               <AddFundsForm
                 depositFund={depositFund}
-                onSuccess={refreshLedgerInfo}
+                onSuccess={(amount) => {
+                  addTransaction({
+                    type: 'deposit',
+                    amount: String(amount),
+                    status: 'completed',
+                    description: `Deposited ${amount} 0G to account`,
+                  });
+                  refreshLedgerInfo();
+                }}
               />
             </TabsContent>
 
@@ -300,7 +342,7 @@ function LedgerContent() {
                 transactions={transactions}
                 isLoading={txLoading}
                 onRefresh={refreshTransactions}
-                explorerBaseUrl="https://chainscan-newton.0g.ai"
+                explorerBaseUrl={explorerBaseUrl}
               />
             </TabsContent>
         </div>
@@ -317,7 +359,15 @@ function LedgerContent() {
           if (!broker) throw new Error('Broker not initialized');
           return broker.ledger.refund(amount);
         }}
-        onSuccess={refreshLedgerInfo}
+        onSuccess={(amount) => {
+          addTransaction({
+            type: 'retrieve',
+            amount: String(amount),
+            status: 'completed',
+            description: `Withdrew ${amount} 0G to wallet`,
+          });
+          refreshLedgerInfo();
+        }}
         onDeleteSuccess={() => window.location.href = '/'}
       />
     </div>


### PR DESCRIPTION
## Summary / What changed

- **Wire `addTransaction()` into 6 fund operations** in `page.tsx`: deposit (via AddFundsForm), withdraw (via WithdrawDialog), retrieve all, retrieve inference, retrieve fine-tuning, retrieve per-provider
- **Fix explorer URL**: replace hardcoded `chainscan-newton.0g.ai` with dynamic chain-config-based URL (`chainscan.0g.ai` for mainnet, `chainscan-galileo.0g.ai` for testnet)
- **Scope localStorage by wallet address**: change key from flat `'transactionHistory'` to `'0g_tx_history_${address}'` to prevent cross-wallet data mixing
- **Remove dead code**: `updateTransactionStatus` was exported but never imported anywhere
- **Enhance callback signatures**: `AddFundsForm.onSuccess` and `WithdrawDialog.onSuccess` now pass the amount back to the caller

## Why

The History tab on `/wallet` always shows "No transactions found" because `addTransaction()` was defined in the `useTransactionHistory` hook and destructured in `page.tsx` but **never called anywhere**. Users see an empty history despite having real on-chain activity, which undermines trust in the platform's transparency.

Additionally, the explorer URL was hardcoded to `chainscan-newton.0g.ai` (Newton was the previous testnet). The current testnet is Galileo (`chainscan-galileo.0g.ai`) and mainnet is `chainscan.0g.ai`.

## Scope

This is a **Tier 1 fix** covering the 6 integration points accessible in `page.tsx` scope. A follow-up Tier 2 PR would lift `useTransactionHistory` into a React Context Provider to also cover DepositModal, TopUpModal, and TransferFundForm (which currently need prop drilling).

**Note**: The SDK's `sendTx()` returns `void` (tx hash is logged to console but not returned), so `txHash` fields remain empty for now. A Tier 3 fix would involve SDK changes + on-chain event queries.

## Files changed (4)

| File | Change |
|------|--------|
| `page.tsx` | Wire `addTransaction` into handlers, dynamic explorer URL, pass wallet address to hook |
| `TransactionHistory.tsx` | Accept `walletAddress` param, scope localStorage key, remove dead `updateTransactionStatus` |
| `AddFundsForm.tsx` | `onSuccess` now passes deposit amount |
| `WithdrawDialog.tsx` | `onSuccess` now passes withdrawal amount |

## Tests

- Manual: Connect wallet → deposit → check History tab → transaction appears
- Manual: Switch between testnet/mainnet → explorer links point to correct domain
- Manual: Connect different wallet → history is separate per address

## Issue

Fixes #176