### PR TITLE
feat(web-ui): display model owner info on provider cards

### DIFF
--- a/web-ui/pnpm-lock.yaml
+++ b/web-ui/pnpm-lock.yaml
@@ -9343,7 +9343,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9365,7 +9365,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/web-ui/src/app/inference/components/OptimizedInferencePage.tsx
+++ b/web-ui/src/app/inference/components/OptimizedInferencePage.tsx
@@ -67,7 +67,7 @@ export function OptimizedInferencePage() {
             if (!activeBroker) throw new Error('Broker not available')
 
             try {
-                const services = await activeBroker.inference.listService()
+                const services = await activeBroker.inference.listServiceWithDetail()
                 return transformBrokerServicesToProviders(services)
             } catch {
                 return []

--- a/web-ui/src/app/inference/components/ProviderCard.tsx
+++ b/web-ui/src/app/inference/components/ProviderCard.tsx
@@ -235,6 +235,13 @@ export function ProviderCard({
                             )}
                         </div>
 
+                        {/* Owner info */}
+                        {provider.ownedBy && (
+                            <p className="text-xs text-muted-foreground mt-1.5">
+                                by {provider.ownedBy}
+                            </p>
+                        )}
+
                         {/* Pricing and address */}
                         <div className="flex items-center gap-2 flex-wrap mt-3">
                             {/* Pricing section - improved clarity */}

--- a/web-ui/src/app/inference/hooks/useProviderManagement.ts
+++ b/web-ui/src/app/inference/hooks/useProviderManagement.ts
@@ -82,7 +82,7 @@ export function useProviderManagement(
         const fetchProviders = async () => {
             if (activeBroker) {
                 try {
-                    const services = await activeBroker.inference.listService()
+                    const services = await activeBroker.inference.listServiceWithDetail()
 
                     if (cancelled) return
 

--- a/web-ui/src/app/inference/hooks/useServiceProviders.ts
+++ b/web-ui/src/app/inference/hooks/useServiceProviders.ts
@@ -90,8 +90,8 @@ export function useServiceProviders(
         setError(null)
 
         try {
-            // Use the broker to get real service list
-            const services = await activeBroker.inference.listService()
+            // Use the broker to get real service list with detail (includes modelInfo.owned_by)
+            const services = await activeBroker.inference.listServiceWithDetail()
 
             // Transform services to Provider format
             const transformedProviders = transformBrokerServicesToProviders(services)

--- a/web-ui/src/app/inference/utils/providerTransform.ts
+++ b/web-ui/src/app/inference/utils/providerTransform.ts
@@ -18,6 +18,9 @@ export interface BrokerServiceObject {
   outputPrice?: bigint | string | number;
   teeSignerAcknowledged?: boolean;
   serviceType?: ServiceType; // Added for UI conditional rendering
+  modelInfo?: {
+    owned_by?: string;
+  };
 }
 
 /**
@@ -37,6 +40,9 @@ export function transformBrokerServiceToProvider(service: unknown): Provider {
     outputPrice?: bigint;
     teeSignerAcknowledged?: boolean;
     serviceType?: ServiceType;
+    modelInfo?: {
+      owned_by?: string;
+    };
   };
   
   // Type guard to ensure service has the required properties
@@ -73,6 +79,7 @@ export function transformBrokerServiceToProvider(service: unknown): Provider {
     outputPriceNeuron: serviceObj.outputPrice ? BigInt(serviceObj.outputPrice) : undefined,
     teeSignerAcknowledged: serviceObj.teeSignerAcknowledged ?? false,
     serviceType: serviceObj.serviceType, // Pass through for UI conditional rendering
+    ownedBy: serviceObj.modelInfo?.owned_by,
   };
 }
 

--- a/web-ui/src/shared/types/broker.ts
+++ b/web-ui/src/shared/types/broker.ts
@@ -52,6 +52,7 @@ export interface Provider {
   outputPriceNeuron?: bigint;
   teeSignerAcknowledged?: boolean;
   serviceType?: ServiceType;
+  ownedBy?: string;
   // Health status from compute-status API
   healthStatus?: 'healthy' | 'warning' | 'critical' | 'unknown';
   uptime?: number; // percentage


### PR DESCRIPTION
## Summary
- Switch all `listService()` calls to `listServiceWithDetail()` to get enriched model metadata
- Extract `owned_by` from `modelInfo` and display it as "by {owner}" on ProviderCard
- Add `ownedBy` field to `Provider` type and wire it through the transform layer

## Changed Files
- `web-ui/src/shared/types/broker.ts` — added `ownedBy?: string` to Provider interface
- `web-ui/src/app/inference/utils/providerTransform.ts` — extract `modelInfo.owned_by` into `ownedBy`
- `web-ui/src/app/inference/hooks/useServiceProviders.ts` — `listService()` → `listServiceWithDetail()`
- `web-ui/src/app/inference/hooks/useProviderManagement.ts` — `listService()` → `listServiceWithDetail()`
- `web-ui/src/app/inference/components/OptimizedInferencePage.tsx` — `listService()` → `listServiceWithDetail()`
- `web-ui/src/app/inference/components/ProviderCard.tsx` — render owner info below badges

## Test plan
- [x] Verified locally that ProviderCard displays "by OG Foundation" correctly
- [ ] Confirm owner info renders for providers that have `owned_by` in model metadata
- [ ] Confirm cards without `owned_by` do not show the owner line

🤖 Generated with [Claude Code](https://claude.com/claude-code)