### PR TITLE
Add support for centralized LLM providers in attestation verification

### DIFF
--- a/src.ts/sdk/inference/broker/response.ts
+++ b/src.ts/sdk/inference/broker/response.ts
@@ -64,7 +64,12 @@ export class ResponseProcessor extends ZGServingUserBrokerBase {
 
             try {
                 const additionalInfo = JSON.parse(svc.additionalInfo)
-                const isCentralized = additionalInfo.ProviderType === 'centralized'
+                let providerType = additionalInfo.ProviderType || 'decentralized'
+                if (providerType !== 'decentralized' && providerType !== 'centralized') {
+                    logger.warn(`Invalid ProviderType: ${providerType}, defaulting to 'decentralized'`)
+                    providerType = 'decentralized'
+                }
+                const isCentralized = providerType === 'centralized'
 
                 if (
                     additionalInfo.TargetSeparated === true &&

--- a/src.ts/sdk/inference/broker/response.ts
+++ b/src.ts/sdk/inference/broker/response.ts
@@ -64,12 +64,18 @@ export class ResponseProcessor extends ZGServingUserBrokerBase {
 
             try {
                 const additionalInfo = JSON.parse(svc.additionalInfo)
+                const isCentralized = additionalInfo.ProviderType === 'centralized'
+
                 if (
                     additionalInfo.TargetSeparated === true &&
+                    !isCentralized &&
                     additionalInfo.TargetTeeAddress
                 ) {
+                    // Separated decentralized: LLM runs in its own TEE, verify against LLM's TEE signer
                     signingAddress = additionalInfo.TargetTeeAddress
                 }
+                // For centralized providers (TargetSeparated=true but ProviderType='centralized'),
+                // the broker TEE signs the response, so we keep svc.teeSignerAddress
             } catch (error) {
                 // If JSON parsing fails, fall back to using additionalInfo as the address directly (backward compatibility)
                 logger.warn('Failed to parse additionalInfo as JSON', error)

--- a/src.ts/sdk/inference/broker/verifier.ts
+++ b/src.ts/sdk/inference/broker/verifier.ts
@@ -483,7 +483,10 @@ export class Verifier extends ZGServingUserBrokerBase {
                 log('info', '   2. Verify the downloaded attestation report(s):')
 
                 // Show specific commands based on whether components are separated
-                if (targetSeparated) {
+                if (targetSeparated && isCentralized) {
+                    log('info', '      # Verify broker attestation report (centralized provider - broker TEE only)')
+                    log('info', `      curl -s -d @${outputDir}/broker_attestation_report.json localhost:8080/verify`)
+                } else if (targetSeparated) {
                     log('info', '      # Verify broker attestation report')
                     log('info', `      curl -s -d @${outputDir}/broker_attestation_report.json localhost:8080/verify`)
                     log('info', '')

--- a/src.ts/sdk/inference/broker/verifier.ts
+++ b/src.ts/sdk/inference/broker/verifier.ts
@@ -60,6 +60,8 @@ export interface VerificationResult {
     steps?: VerificationStep[]
 }
 
+export type ProviderType = 'decentralized' | 'centralized'
+
 export interface AdditionalInfo {
     VerifierURL?: string
     TargetSeparated?: boolean
@@ -67,7 +69,7 @@ export interface AdditionalInfo {
     TargetTeeAddress?: string
     ImageName?: string
     ImageDigest?: string
-    ProviderType?: string // 'decentralized' | 'centralized' - distinguishes separated TEE from centralized (e.g. OpenAI/Anthropic)
+    ProviderType?: ProviderType
 }
 
 export interface AttestationReport {
@@ -164,7 +166,11 @@ export class Verifier extends ZGServingUserBrokerBase {
 
             const verifierURL = additionalInfo.VerifierURL
             const targetSeparated = additionalInfo.TargetSeparated === true
-            const providerType = additionalInfo.ProviderType || 'decentralized' // default to decentralized for backward compatibility
+            let providerType: ProviderType = additionalInfo.ProviderType || 'decentralized'
+            if (providerType !== 'decentralized' && providerType !== 'centralized') {
+                log('warning', `⚠️  Invalid ProviderType: ${providerType}, defaulting to 'decentralized'`)
+                providerType = 'decentralized'
+            }
             const isCentralized = providerType === 'centralized'
             const teeVerifier = additionalInfo.TEEVerifier || 'dstack' // default to dstack
             const imageName = additionalInfo.ImageName

--- a/src.ts/sdk/inference/broker/verifier.ts
+++ b/src.ts/sdk/inference/broker/verifier.ts
@@ -67,6 +67,7 @@ export interface AdditionalInfo {
     TargetTeeAddress?: string
     ImageName?: string
     ImageDigest?: string
+    ProviderType?: string // 'decentralized' | 'centralized' - distinguishes separated TEE from centralized (e.g. OpenAI/Anthropic)
 }
 
 export interface AttestationReport {
@@ -163,6 +164,8 @@ export class Verifier extends ZGServingUserBrokerBase {
 
             const verifierURL = additionalInfo.VerifierURL
             const targetSeparated = additionalInfo.TargetSeparated === true
+            const providerType = additionalInfo.ProviderType || 'decentralized' // default to decentralized for backward compatibility
+            const isCentralized = providerType === 'centralized'
             const teeVerifier = additionalInfo.TEEVerifier || 'dstack' // default to dstack
             const imageName = additionalInfo.ImageName
             const imageDigest = additionalInfo.ImageDigest
@@ -194,7 +197,10 @@ export class Verifier extends ZGServingUserBrokerBase {
             }
 
             // Component architecture information
-            if (targetSeparated) {
+            if (targetSeparated && isCentralized) {
+                log('info', '   Architecture: Centralized (Broker in TEE, LLM via centralized provider e.g. OpenAI/Anthropic)')
+                log('info', '   Required Reports: 1 (Broker only)')
+            } else if (targetSeparated) {
                 log('info', '   Architecture: Separated (Broker and LLM inference in different TEE nodes)')
                 log('info', '   Required Reports: 2 (Broker + LLM inference)')
             } else {
@@ -211,8 +217,18 @@ export class Verifier extends ZGServingUserBrokerBase {
             log('step', '📥 Step 3: Downloading attestation reports...')
             const reports: Record<string, AttestationReport> = {}
 
-            if (targetSeparated) {
-                // Get both broker and LLM reports
+            if (targetSeparated && isCentralized) {
+                // Centralized provider: only broker runs in TEE, LLM is a centralized service (e.g. OpenAI/Anthropic)
+                log('info', '   Downloading broker attestation report (centralized provider - no LLM TEE)...')
+                const brokerReport = await this.getQuote(providerAddress)
+                const brokerPath = `${outputDir}/broker_attestation_report.json`
+                await this.saveReportToFile(brokerReport.rawReport, brokerPath)
+                reports.broker = JSON.parse(
+                    brokerReport.rawReport
+                ) as AttestationReport
+                log('success', `   ✅ Broker report saved to: ${brokerPath}`)
+            } else if (targetSeparated) {
+                // Separated decentralized: both broker and LLM run in separate TEE nodes
                 log('info', '   Downloading broker attestation report...')
                 const brokerReport = await this.getQuote(providerAddress)
                 const brokerPath = `${outputDir}/broker_attestation_report.json`


### PR DESCRIPTION
## Summary
This PR adds support for centralized LLM providers (e.g., OpenAI, Anthropic) in the attestation verification flow. Previously, the system only supported decentralized architectures where both the broker and LLM inference run in separate TEE nodes. This change introduces a new `ProviderType` field to distinguish between decentralized and centralized provider setups.

## Key Changes

- **Added `ProviderType` field** to `AdditionalInfo` interface to distinguish between 'decentralized' and 'centralized' provider architectures
  - Defaults to 'decentralized' for backward compatibility

- **Updated attestation report verification logic** in `Verifier` class:
  - Added conditional logic to handle centralized provider case where only the broker runs in TEE
  - For centralized providers: downloads and verifies only the broker attestation report
  - For decentralized providers: downloads and verifies both broker and LLM inference reports
  - Updated logging to clearly indicate the architecture type and number of required reports

- **Updated response signing logic** in `ResponseProcessor` class:
  - For centralized providers: uses the broker TEE's signing address (even when `TargetSeparated=true`)
  - For decentralized providers: uses the target LLM TEE's signing address for verification
  - Added clarifying comments explaining the different signing scenarios

## Implementation Details

- The `isCentralized` flag is derived from `ProviderType === 'centralized'` and used throughout the verification flow
- Backward compatibility is maintained by defaulting to 'decentralized' when `ProviderType` is not specified
- The centralized flow skips LLM TEE report verification since the LLM is a centralized service outside the TEE ecosystem

https://claude.ai/code/session_01PPm8o782Jcg9X75iapt7ER