### PR TITLE
feat: add tiered pricing display and CLI improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0glabs/0g-serving-broker",
-    "version": "0.7.4",
+    "version": "0.7.5",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {

--- a/src.ts/cli/cli.ts
+++ b/src.ts/cli/cli.ts
@@ -15,7 +15,7 @@ export const program = new Command()
 program
     .name('0g-compute-cli')
     .description('CLI for interacting with ZG Compute Network')
-    .version('0.7.4')
+    .version('0.7.5')
 
 ledger(program)
 

--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -11,6 +11,59 @@ import axios from 'axios'
 import fs from 'fs'
 import { ethers } from 'ethers'
 import { formatError } from '../sdk/common/utils/error-handler'
+import { parseTieredPricing, parseCacheTokenBilling } from '../sdk/inference'
+import type { TieredPricingInfo, CacheTokenBillingInfo } from '../sdk/inference'
+
+/**
+ * Format a token count for display (e.g., 256000 -> "256k", 1000000 -> "1M")
+ */
+function formatTokenCount(tokens: number): string {
+    if (tokens >= 1000000) return `${tokens / 1000000}M`
+    if (tokens >= 1000) return `${tokens / 1000}k`
+    return `${tokens}`
+}
+
+/**
+ * Format a price value, trimming unnecessary trailing zeros while keeping
+ * enough precision to distinguish non-zero values.
+ */
+function formatPrice(neurons: bigint): string {
+    const s = neuronToA0gi(neurons).toFixed(18)
+    // Keep at least one trailing zero after decimal point for readability
+    return s.replace(/(\.\d*?[1-9])0+$/, '$1').replace(/\.0+$/, '.0')
+}
+
+/**
+ * Push tiered pricing rows into a CLI table.
+ * Each tier is displayed as a single compact row with all prices.
+ */
+function pushTieredPricingRows(
+    table: Table.Table,
+    baseInputPrice: bigint,
+    baseOutputPrice: bigint,
+    tieredPricing: TieredPricingInfo,
+    cacheBilling?: CacheTokenBillingInfo
+) {
+    table.push([chalk.yellow('Tiered Pricing (0G/Token)'), chalk.yellow('Enabled')])
+    let prevLabel = '0'
+    for (const tier of tieredPricing.tiers) {
+        const rangeLabel = tier.maxInputTokens === 0
+            ? `>${prevLabel}`
+            : `${prevLabel}-${formatTokenCount(tier.maxInputTokens)}`
+        const effectiveInputPrice = baseInputPrice * BigInt(tier.inputMultiplier)
+        const inPrice = formatPrice(effectiveInputPrice)
+        const outPrice = formatPrice(baseOutputPrice * BigInt(tier.outputMultiplier))
+        let priceStr = `In: ${inPrice} / Out: ${outPrice}`
+        if (cacheBilling) {
+            const cachePrice = formatPrice(effectiveInputPrice / BigInt(cacheBilling.divisor))
+            priceStr += ` / Cache: ${cachePrice}`
+        }
+        table.push([`  Input ${rangeLabel} tokens`, priceStr])
+        if (tier.maxInputTokens !== 0) {
+            prevLabel = formatTokenCount(tier.maxInputTokens)
+        }
+    }
+}
 
 async function promptDurationSelection(): Promise<number> {
     console.log(chalk.blue('\n⏱️  API Key Duration Selection'))
@@ -80,7 +133,7 @@ export default function inference(program: Command) {
         )
         .action(async (options: any) => {
             const table = new Table({
-                colWidths: [50, 50],
+                colWidths: [40, 60],
             })
             await withROBroker(options, async (broker) => {
                 const services = await broker.inference.listService(
@@ -95,36 +148,57 @@ export default function inference(program: Command) {
                     ])
                     table.push(['Model', service.model || 'N/A'])
 
-                    // Only show input price for non text-to-image and non image-editing services
-                    if (
-                        service.serviceType !== 'text-to-image' &&
-                        service.serviceType !== 'image-editing'
-                    ) {
-                        table.push([
-                            'Input Price Per Token (0G)',
-                            service.inputPrice
-                                ? neuronToA0gi(
-                                    BigInt(service.inputPrice)
-                                ).toFixed(18)
-                                : 'N/A',
-                        ])
-                    }
 
-                    // Change output price label for text-to-image and image-editing services
-                    const outputPriceLabel =
+                    // Check for tiered pricing and cache billing in additionalInfo
+                    const tiered = parseTieredPricing(service.additionalInfo)
+                    const cacheBilling = parseCacheTokenBilling(service.additionalInfo)
+                    const isImageService =
                         service.serviceType === 'text-to-image' ||
-                            service.serviceType === 'image-editing'
+                        service.serviceType === 'image-editing'
+
+                    if (tiered && !isImageService) {
+                        // Display tiered pricing with optional cache hit prices
+                        pushTieredPricingRows(
+                            table,
+                            BigInt(service.inputPrice),
+                            BigInt(service.outputPrice),
+                            tiered,
+                            cacheBilling
+                        )
+                    } else {
+                        // Original flat pricing display
+                        if (!isImageService) {
+                            table.push([
+                                'Input Price Per Token (0G)',
+                                service.inputPrice
+                                    ? neuronToA0gi(
+                                        BigInt(service.inputPrice)
+                                    ).toFixed(18)
+                                    : 'N/A',
+                            ])
+                        }
+
+                        const outputPriceLabel = isImageService
                             ? 'Price Per Image (OG)'
                             : 'Output Price Per Token (0G)'
 
-                    table.push([
-                        outputPriceLabel,
-                        service.outputPrice
-                            ? neuronToA0gi(BigInt(service.outputPrice)).toFixed(
-                                18
-                            )
-                            : 'N/A',
-                    ])
+                        table.push([
+                            outputPriceLabel,
+                            service.outputPrice
+                                ? neuronToA0gi(
+                                    BigInt(service.outputPrice)
+                                ).toFixed(18)
+                                : 'N/A',
+                        ])
+
+                        // Show cache hit price for flat pricing (non-image services)
+                        if (cacheBilling && !isImageService && service.inputPrice) {
+                            const cacheHitPrice = neuronToA0gi(
+                                BigInt(service.inputPrice) / BigInt(cacheBilling.divisor)
+                            ).toFixed(18)
+                            table.push(['Cache Hit Price Per Token (0G)', cacheHitPrice])
+                        }
+                    }
                     table.push([
                         'Verifiability',
                         service.verifiability || 'N/A',
@@ -148,7 +222,7 @@ export default function inference(program: Command) {
         )
         .action(async (options: any) => {
             const table = new Table({
-                colWidths: [50, 50],
+                colWidths: [40, 60],
             })
             await withROBroker(options, async (broker) => {
                 const services = await broker.inference.listServiceWithDetail(
@@ -207,36 +281,52 @@ export default function inference(program: Command) {
                         ])
                     }
 
-                    // Only show input price for non text-to-image and non image-editing services
-                    if (
-                        service.serviceType !== 'text-to-image' &&
-                        service.serviceType !== 'image-editing'
-                    ) {
-                        table.push([
-                            'Input Price Per Token (0G)',
-                            service.inputPrice
-                                ? neuronToA0gi(
-                                    BigInt(service.inputPrice)
-                                ).toFixed(18)
-                                : 'N/A',
-                        ])
-                    }
-
-                    // Change output price label for text-to-image and image-editing services
-                    const outputPriceLabel =
+                    // Pricing display
+                    const isImageService =
                         service.serviceType === 'text-to-image' ||
-                            service.serviceType === 'image-editing'
+                        service.serviceType === 'image-editing'
+
+                    if (service.tieredPricing && !isImageService) {
+                        pushTieredPricingRows(
+                            table,
+                            BigInt(service.inputPrice),
+                            BigInt(service.outputPrice),
+                            service.tieredPricing,
+                            service.cacheTokenBilling
+                        )
+                    } else {
+                        if (!isImageService) {
+                            table.push([
+                                'Input Price Per Token (0G)',
+                                service.inputPrice
+                                    ? neuronToA0gi(
+                                        BigInt(service.inputPrice)
+                                    ).toFixed(18)
+                                    : 'N/A',
+                            ])
+                        }
+
+                        const outputPriceLabel = isImageService
                             ? 'Price Per Image (OG)'
                             : 'Output Price Per Token (0G)'
 
-                    table.push([
-                        outputPriceLabel,
-                        service.outputPrice
-                            ? neuronToA0gi(BigInt(service.outputPrice)).toFixed(
-                                18
-                            )
-                            : 'N/A',
-                    ])
+                        table.push([
+                            outputPriceLabel,
+                            service.outputPrice
+                                ? neuronToA0gi(
+                                    BigInt(service.outputPrice)
+                                ).toFixed(18)
+                                : 'N/A',
+                        ])
+
+                        // Show cache hit price for flat pricing (non-image services)
+                        if (service.cacheTokenBilling && !isImageService && service.inputPrice) {
+                            const cacheHitPrice = neuronToA0gi(
+                                BigInt(service.inputPrice) / BigInt(service.cacheTokenBilling.divisor)
+                            ).toFixed(18)
+                            table.push(['Cache Hit Price Per Token (0G)', cacheHitPrice])
+                        }
+                    }
                     table.push([
                         'Verifiability',
                         service.verifiability || 'N/A',

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -82,6 +82,16 @@ export interface ProviderModelInfo {
         completion?: string
         /** Price per generated image (text-to-image services) */
         image?: string
+        /** Tiered pricing tiers based on input token count */
+        tiered_pricing?: Array<{
+            max_input_tokens: number
+            input_multiplier: number
+            output_multiplier: number
+        }>
+        /** Cache token billing configuration */
+        cache_token_billing?: {
+            divisor: number
+        }
     }
     /** ISO 8601 date string indicating when this model will no longer be served */
     expiration_date?: string
@@ -89,6 +99,131 @@ export interface ProviderModelInfo {
     tee_attested?: boolean
     tee_type?: string
     tee_verifier?: string
+}
+
+/**
+ * A single pricing tier for input-length-based tiered pricing.
+ * Tiers are ordered by maxInputTokens ascending.
+ * maxInputTokens: 0 means unlimited (the highest tier).
+ */
+export interface PricingTier {
+    maxInputTokens: number
+    inputMultiplier: number
+    outputMultiplier: number
+}
+
+/**
+ * Tiered pricing configuration parsed from service additionalInfo.
+ */
+export interface TieredPricingInfo {
+    tiers: PricingTier[]
+}
+
+/**
+ * Parse tiered pricing info from service additionalInfo JSON string.
+ * Returns undefined if not present or invalid.
+ */
+export function parseTieredPricing(
+    additionalInfo: string
+): TieredPricingInfo | undefined {
+    try {
+        const parsed = JSON.parse(additionalInfo)
+        if (
+            parsed?.tieredPricing?.tiers &&
+            Array.isArray(parsed.tieredPricing.tiers)
+        ) {
+            const tiers: PricingTier[] = parsed.tieredPricing.tiers
+                .filter(
+                    (t: any) =>
+                        typeof t.maxInputTokens === 'number' &&
+                        typeof t.inputMultiplier === 'number' &&
+                        typeof t.outputMultiplier === 'number'
+                )
+                .map((t: any) => ({
+                    maxInputTokens: t.maxInputTokens,
+                    inputMultiplier: t.inputMultiplier,
+                    outputMultiplier: t.outputMultiplier,
+                }))
+            if (tiers.length > 0) {
+                return { tiers }
+            }
+        }
+    } catch {
+        // additionalInfo is not valid JSON or doesn't contain tieredPricing
+    }
+    return undefined
+}
+
+/**
+ * Parse tiered pricing from ProviderModelInfo (returned by /v1/models endpoint).
+ * Returns undefined if not present.
+ */
+export function parseTieredPricingFromModelInfo(
+    modelInfo?: ProviderModelInfo
+): TieredPricingInfo | undefined {
+    const raw = modelInfo?.pricing?.tiered_pricing
+    if (!raw || !Array.isArray(raw) || raw.length === 0) {
+        return undefined
+    }
+    const tiers: PricingTier[] = raw
+        .filter(
+            (t) =>
+                typeof t.max_input_tokens === 'number' &&
+                typeof t.input_multiplier === 'number' &&
+                typeof t.output_multiplier === 'number'
+        )
+        .map((t) => ({
+            maxInputTokens: t.max_input_tokens,
+            inputMultiplier: t.input_multiplier,
+            outputMultiplier: t.output_multiplier,
+        }))
+    if (tiers.length > 0) {
+        return { tiers }
+    }
+    return undefined
+}
+
+/**
+ * Cache token billing configuration parsed from service additionalInfo or modelInfo.
+ */
+export interface CacheTokenBillingInfo {
+    divisor: number
+}
+
+/**
+ * Parse cache token billing info from service additionalInfo JSON string.
+ * Returns undefined if not present or invalid.
+ */
+export function parseCacheTokenBilling(
+    additionalInfo: string
+): CacheTokenBillingInfo | undefined {
+    try {
+        const parsed = JSON.parse(additionalInfo)
+        if (
+            parsed?.cacheTokenBilling &&
+            typeof parsed.cacheTokenBilling.divisor === 'number' &&
+            parsed.cacheTokenBilling.divisor > 0
+        ) {
+            return { divisor: parsed.cacheTokenBilling.divisor }
+        }
+    } catch {
+        // additionalInfo is not valid JSON or doesn't contain cacheTokenBilling
+    }
+    return undefined
+}
+
+/**
+ * Parse cache token billing from ProviderModelInfo (returned by /v1/models endpoint).
+ * Returns undefined if not present.
+ */
+export function parseCacheTokenBillingFromModelInfo(
+    modelInfo?: ProviderModelInfo
+): CacheTokenBillingInfo | undefined {
+    const raw = modelInfo?.pricing?.cache_token_billing
+    if (raw && typeof raw.divisor === 'number' && raw.divisor > 0) {
+        return { divisor: raw.divisor }
+    }
+    return undefined
 }
 
 /**
@@ -113,6 +248,8 @@ export interface ServiceWithDetail {
         lastCheck: string
     }
     modelInfo?: ProviderModelInfo
+    tieredPricing?: TieredPricingInfo
+    cacheTokenBilling?: CacheTokenBillingInfo
 }
 
 /**
@@ -260,6 +397,12 @@ export class ReadOnlyModelProcessor {
                             }
                             : undefined,
                         modelInfo,
+                        tieredPricing:
+                            parseTieredPricing(service.additionalInfo) ??
+                            parseTieredPricingFromModelInfo(modelInfo),
+                        cacheTokenBilling:
+                            parseCacheTokenBilling(service.additionalInfo) ??
+                            parseCacheTokenBillingFromModelInfo(modelInfo),
                     }
                 }
             )

--- a/src.ts/sdk/inference/index.ts
+++ b/src.ts/sdk/inference/index.ts
@@ -15,4 +15,11 @@ export {
     ReadOnlyInferenceBroker,
     createReadOnlyInferenceBroker,
 } from './broker'
-export type { ProviderModelInfo, ServiceWithDetail } from './broker'
+export type {
+    ProviderModelInfo,
+    ServiceWithDetail,
+    PricingTier,
+    TieredPricingInfo,
+    CacheTokenBillingInfo,
+} from './broker'
+export { parseTieredPricing, parseCacheTokenBilling } from './broker'

--- a/web-ui/pnpm-lock.yaml
+++ b/web-ui/pnpm-lock.yaml
@@ -9343,7 +9343,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9365,7 +9365,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/web-ui/src/app/inference/components/ProviderCard.tsx
+++ b/web-ui/src/app/inference/components/ProviderCard.tsx
@@ -46,6 +46,12 @@ interface ProviderCardProps {
     onSpeechToText?: (provider: Provider) => void
 }
 
+function formatTokens(count: number): string {
+    if (count >= 1000000) return `${count / 1000000}M`
+    if (count >= 1000) return `${count / 1000}k`
+    return `${count}`
+}
+
 export function ProviderCard({
     provider,
     isOfficial,
@@ -244,7 +250,7 @@ export function ProviderCard({
 
                         {/* Pricing and address */}
                         <div className="flex items-center gap-2 flex-wrap mt-3">
-                            {/* Pricing section - improved clarity */}
+                            {/* Pricing section */}
                             {(provider.inputPrice !== undefined ||
                                 provider.outputPrice !== undefined) && (
                                 <Tooltip>
@@ -260,6 +266,48 @@ export function ProviderCard({
                                                             4
                                                         )}{' '}
                                                         0G/image
+                                                    </span>
+                                                </div>
+                                            ) : provider.tieredPricing ? (
+                                                <div className="flex items-center gap-1">
+                                                    <span className="text-muted-foreground">
+                                                        In:
+                                                    </span>
+                                                    <span className="font-semibold text-foreground">
+                                                        {provider.inputPrice?.toFixed(
+                                                            2
+                                                        )}
+                                                        ~
+                                                        {(
+                                                            (provider.inputPrice ?? 0) *
+                                                            Math.max(
+                                                                ...provider.tieredPricing.tiers.map(
+                                                                    (t) =>
+                                                                        t.inputMultiplier
+                                                                )
+                                                            )
+                                                        ).toFixed(2)}
+                                                    </span>
+                                                    <span className="text-muted-foreground">
+                                                        Out:
+                                                    </span>
+                                                    <span className="font-semibold text-foreground">
+                                                        {provider.outputPrice?.toFixed(
+                                                            2
+                                                        )}
+                                                        ~
+                                                        {(
+                                                            (provider.outputPrice ?? 0) *
+                                                            Math.max(
+                                                                ...provider.tieredPricing.tiers.map(
+                                                                    (t) =>
+                                                                        t.outputMultiplier
+                                                                )
+                                                            )
+                                                        ).toFixed(2)}
+                                                    </span>
+                                                    <span className="text-muted-foreground">
+                                                        0G/1M
                                                     </span>
                                                 </div>
                                             ) : (
@@ -310,6 +358,78 @@ export function ProviderCard({
                                                     )}{' '}
                                                     0G
                                                 </p>
+                                            ) : provider.tieredPricing ? (
+                                                <div className="space-y-1">
+                                                    <p className="text-xs text-muted-foreground mb-1">
+                                                        Tiered pricing based on input length
+                                                    </p>
+                                                    {provider.tieredPricing.tiers.map(
+                                                        (tier, i) => {
+                                                            const prevMax =
+                                                                i > 0
+                                                                    ? provider.tieredPricing!
+                                                                          .tiers[
+                                                                          i - 1
+                                                                      ]
+                                                                          .maxInputTokens
+                                                                    : 0
+                                                            const label =
+                                                                tier.maxInputTokens ===
+                                                                0
+                                                                    ? `>${formatTokens(prevMax)}`
+                                                                    : prevMax ===
+                                                                        0
+                                                                      ? `<=${formatTokens(tier.maxInputTokens)}`
+                                                                      : `${formatTokens(prevMax)}-${formatTokens(tier.maxInputTokens)}`
+                                                            return (
+                                                                <div
+                                                                    key={i}
+                                                                    className="border-t border-border pt-1"
+                                                                >
+                                                                    <p className="font-medium text-xs">
+                                                                        {label}{' '}
+                                                                        tokens
+                                                                    </p>
+                                                                    <p>
+                                                                        Input:{' '}
+                                                                        {(
+                                                                            (provider.inputPrice ??
+                                                                                0) *
+                                                                            tier.inputMultiplier
+                                                                        ).toFixed(
+                                                                            4
+                                                                        )}{' '}
+                                                                        0G/1M
+                                                                    </p>
+                                                                    <p>
+                                                                        Output:{' '}
+                                                                        {(
+                                                                            (provider.outputPrice ??
+                                                                                0) *
+                                                                            tier.outputMultiplier
+                                                                        ).toFixed(
+                                                                            4
+                                                                        )}{' '}
+                                                                        0G/1M
+                                                                    </p>
+                                                                    {provider.cacheTokenBilling && (
+                                                                        <p>
+                                                                            Cache Hit:{' '}
+                                                                            {(
+                                                                                ((provider.inputPrice ?? 0) *
+                                                                                    tier.inputMultiplier) /
+                                                                                provider.cacheTokenBilling.divisor
+                                                                            ).toFixed(
+                                                                                4
+                                                                            )}{' '}
+                                                                            0G/1M
+                                                                        </p>
+                                                                    )}
+                                                                </div>
+                                                            )
+                                                        }
+                                                    )}
+                                                </div>
                                             ) : (
                                                 <>
                                                     {provider.inputPrice !==
@@ -331,6 +451,18 @@ export function ProviderCard({
                                                             {provider.outputPrice.toFixed(
                                                                 4
                                                             )}{' '}
+                                                            0G per 1M tokens
+                                                        </p>
+                                                    )}
+                                                    {provider.cacheTokenBilling &&
+                                                        provider.inputPrice !==
+                                                            undefined && (
+                                                        <p>
+                                                            Cache Hit:{' '}
+                                                            {(
+                                                                provider.inputPrice /
+                                                                provider.cacheTokenBilling.divisor
+                                                            ).toFixed(4)}{' '}
                                                             0G per 1M tokens
                                                         </p>
                                                     )}

--- a/web-ui/src/app/inference/utils/providerTransform.ts
+++ b/web-ui/src/app/inference/utils/providerTransform.ts
@@ -1,8 +1,9 @@
 /**
  * Provider service transformation utilities
  */
-import type { Provider, ServiceType } from '../../../shared/types/broker';
+import type { Provider, ServiceType, TieredPricingInfo, CacheTokenBillingInfo } from '../../../shared/types/broker';
 import { neuronToA0gi } from '../../../shared/utils/currency';
+import { parseTieredPricing, parseCacheTokenBilling } from '@0glabs/0g-serving-broker';
 
 /**
  * Service object structure from broker
@@ -18,6 +19,8 @@ export interface BrokerServiceObject {
   outputPrice?: bigint | string | number;
   teeSignerAcknowledged?: boolean;
   serviceType?: ServiceType; // Added for UI conditional rendering
+  additionalInfo?: string;
+  tieredPricing?: TieredPricingInfo; // Pre-parsed from additionalInfo (ServiceWithDetail)
   modelInfo?: {
     owned_by?: string;
   };
@@ -40,6 +43,9 @@ export function transformBrokerServiceToProvider(service: unknown): Provider {
     outputPrice?: bigint;
     teeSignerAcknowledged?: boolean;
     serviceType?: ServiceType;
+    additionalInfo?: string;
+    tieredPricing?: TieredPricingInfo;
+    cacheTokenBilling?: CacheTokenBillingInfo;
     modelInfo?: {
       owned_by?: string;
     };
@@ -67,6 +73,18 @@ export function transformBrokerServiceToProvider(service: unknown): Provider {
     ? neuronToA0gi(serviceObj.outputPrice * priceMultiplier)
     : undefined;
 
+  // Parse tiered pricing: prefer pre-parsed (from ServiceWithDetail), fallback to additionalInfo via SDK
+  let tieredPricing: TieredPricingInfo | undefined = serviceObj.tieredPricing;
+  if (!tieredPricing && serviceObj.additionalInfo) {
+    tieredPricing = parseTieredPricing(serviceObj.additionalInfo);
+  }
+
+  // Parse cache token billing: prefer pre-parsed, fallback to additionalInfo via SDK
+  let cacheTokenBilling: CacheTokenBillingInfo | undefined = serviceObj.cacheTokenBilling;
+  if (!cacheTokenBilling && serviceObj.additionalInfo) {
+    cacheTokenBilling = parseCacheTokenBilling(serviceObj.additionalInfo);
+  }
+
   return {
     address: providerAddress,
     model: modelName,
@@ -80,6 +98,8 @@ export function transformBrokerServiceToProvider(service: unknown): Provider {
     teeSignerAcknowledged: serviceObj.teeSignerAcknowledged ?? false,
     serviceType: serviceObj.serviceType, // Pass through for UI conditional rendering
     ownedBy: serviceObj.modelInfo?.owned_by,
+    tieredPricing,
+    cacheTokenBilling,
   };
 }
 

--- a/web-ui/src/shared/types/broker.ts
+++ b/web-ui/src/shared/types/broker.ts
@@ -39,6 +39,20 @@ export interface ModelSummary {
   providers: Provider[];
 }
 
+export interface PricingTier {
+  maxInputTokens: number;
+  inputMultiplier: number;
+  outputMultiplier: number;
+}
+
+export interface TieredPricingInfo {
+  tiers: PricingTier[];
+}
+
+export interface CacheTokenBillingInfo {
+  divisor: number;
+}
+
 export interface Provider {
   address: string;
   model: string;
@@ -53,6 +67,8 @@ export interface Provider {
   teeSignerAcknowledged?: boolean;
   serviceType?: ServiceType;
   ownedBy?: string;
+  tieredPricing?: TieredPricingInfo;
+  cacheTokenBilling?: CacheTokenBillingInfo;
   // Health status from compute-status API
   healthStatus?: 'healthy' | 'warning' | 'critical' | 'unknown';
   uptime?: number; // percentage


### PR DESCRIPTION
- Add tiered pricing parsing from provider additionalInfo
- Display per-tier input/output prices in CLI table with compact format
- Widen table columns (40/60) to prevent price truncation
- Add unit label (0G/Token) to tiered pricing header
- Add "Input" prefix to tier range labels for clarity
- Trim trailing zeros from price display
- Update web-ui ProviderCard to show tiered pricing
- Bump version to 0.7.5