### PR TITLE
Add bash completion support and shell completion hint

### DIFF
--- a/src.ts/cli/__tests__/completion.test.ts
+++ b/src.ts/cli/__tests__/completion.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { Command } from 'commander'
+import { execFileSync } from 'child_process'
+import { generateBashCompletion, generateZshCompletion } from '../completion'
+
+function buildFixture(): Command {
+    const program = new Command()
+    program.name('0g-compute-cli').version('0.7.5').description('test')
+    program.option('-v, --verbose', 'verbose output')
+
+    const inf = program
+        .command('inference')
+        .alias('inf')
+        .description('Inference')
+    inf.command('list-providers')
+        .option('-d, --detail', 'detail')
+        .option('--json', 'json output')
+    inf.command('verify').option('--chat-id <id>', 'chat id')
+
+    const ft = program
+        .command('fine-tuning')
+        .alias('ft')
+        .description('Fine-tuning')
+    ft.command('create-task').option('-p, --provider <addr>', 'provider')
+
+    return program
+}
+
+describe('completion - bash generator', () => {
+    it('emits a top-level dispatcher function and compdef registration', () => {
+        const script = generateBashCompletion(buildFixture())
+        expect(script).to.include('_0g_compute_cli() {')
+        expect(script).to.include('complete -F _0g_compute_cli 0g-compute-cli')
+    })
+
+    it('includes -h / --help at every node (commander omits these from options)', () => {
+        const script = generateBashCompletion(buildFixture())
+        // Root
+        const rootArm = script.match(/"\"\)[\s\S]*?;;/)?.[0] ?? ''
+        expect(rootArm).to.match(/-h.*--help/)
+        // Inference group
+        const infArm = script.match(/"inference"\|"inf"\)[\s\S]*?;;/)?.[0] ?? ''
+        expect(infArm).to.match(/-h.*--help/)
+        // Leaf (list-providers)
+        const leafArm =
+            script.match(
+                /"inference list-providers"\|"inf list-providers"\)[\s\S]*?;;/
+            )?.[0] ?? ''
+        expect(leafArm).to.match(/-h.*--help/)
+    })
+
+    it('includes -V / --version exactly once at the root (not duplicated)', () => {
+        const script = generateBashCompletion(buildFixture())
+        const rootArm = script.match(/"\"\)[\s\S]*?;;/)?.[0] ?? ''
+        const vOccurrences = (rootArm.match(/--version/g) ?? []).length
+        expect(vOccurrences).to.equal(1)
+    })
+
+    it('deduplicates aliases into a single case arm with | alternation', () => {
+        const script = generateBashCompletion(buildFixture())
+        // Alias group should be a single arm
+        expect(script).to.include('"inference"|"inf")')
+        expect(script).to.include(
+            '"fine-tuning create-task"|"ft create-task")'
+        )
+        // Alias path must never start its own arm (would indicate it was
+        // walked as a separate subtree). It should only ever appear after `|`.
+        const standaloneAliasArm = script.match(
+            /^\s*"inf list-providers"\)/m
+        )
+        expect(standaloneAliasArm, 'aliases must share one arm').to.be.null
+    })
+
+    it('emits subcommands + aliases as completion words at their parent node', () => {
+        const script = generateBashCompletion(buildFixture())
+        const rootArm = script.match(/"\"\)[\s\S]*?;;/)?.[0] ?? ''
+        expect(rootArm).to.include('inference')
+        expect(rootArm).to.include('inf')
+        expect(rootArm).to.include('fine-tuning')
+        expect(rootArm).to.include('ft')
+    })
+
+    it('produces a script that bash can source and complete via compgen', () => {
+        const script = generateBashCompletion(buildFixture())
+        // Run: source script, invoke the completion function with COMP_WORDS
+        // simulating `0g-compute-cli inference <TAB>`, then echo COMPREPLY.
+        const driver = `
+set +e
+${script}
+COMP_WORDS=(0g-compute-cli inference "")
+COMP_CWORD=2
+COMPREPLY=()
+_0g_compute_cli
+printf '%s\\n' "\${COMPREPLY[@]}"
+`
+        const out = execFileSync('bash', ['-c', driver], {
+            encoding: 'utf8',
+        })
+        const replies = out.split('\n').filter(Boolean)
+        expect(replies).to.include('list-providers')
+        expect(replies).to.include('verify')
+        expect(replies).to.include('--help')
+    })
+
+    it('escapes dangerous chars ($ ` " \\) in generated words', () => {
+        const program = new Command()
+        program.name('x').version('1.0')
+        program.command('weird $(cmd)').option('-a', 'desc')
+        const script = generateBashCompletion(program)
+        // No un-escaped $( in the generated words, which would cause shell
+        // injection when the script is sourced.
+        expect(script).to.not.match(/completions="[^"]*\$\([^)]*\)/)
+    })
+})
+
+describe('completion - zsh generator (smoke)', () => {
+    it('emits a compdef header and registration (unchanged by bash work)', () => {
+        const script = generateZshCompletion(buildFixture())
+        expect(script.startsWith('#compdef 0g-compute-cli')).to.equal(true)
+        expect(script).to.include('compdef _0g_compute_cli_main 0g-compute-cli')
+    })
+})

--- a/src.ts/cli/cli.ts
+++ b/src.ts/cli/cli.ts
@@ -9,6 +9,7 @@ import network from './network'
 import auth from './auth'
 import controller from './controller'
 import completion from './completion'
+import { showCompletionHintIfNeeded } from './tips'
 import packageJson from '../../package.json'
 
 export const program = new Command()
@@ -115,6 +116,8 @@ function showUpdateNotification(updateInfo: {
     } catch {
         // Silently fail - don't block CLI usage (e.g., in Yarn PnP environments)
     }
+
+    showCompletionHintIfNeeded(program.name())
 
     program.parse(process.argv)
 })()

--- a/src.ts/cli/completion.ts
+++ b/src.ts/cli/completion.ts
@@ -177,6 +177,10 @@ function collectBashEntries(
         if (o.short) words.push(o.short)
         if (o.long) words.push(o.long)
     }
+    // Commander doesn't register -h/--help in Command#options — it lives on
+    // a private _helpOption — so the option loop above misses it. Match the
+    // zsh generator by appending it to every node unconditionally.
+    words.push('-h', '--help')
     out.push({ path: currentPath, words })
 
     for (const s of subs) {

--- a/src.ts/cli/completion.ts
+++ b/src.ts/cli/completion.ts
@@ -146,6 +146,109 @@ function generateAll(
     return lines
 }
 
+function escapeBashDq(s: string): string {
+    // Escape characters that are still special inside bash double quotes.
+    return s
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\$/g, '\\$')
+        .replace(/`/g, '\\`')
+}
+
+type BashEntry = {
+    path: string[]
+    words: string[]
+}
+
+function collectBashEntries(
+    cmd: Command,
+    currentPath: string[],
+    out: BashEntry[]
+): void {
+    const subs = visibleCommands(cmd)
+    const words: string[] = []
+    for (const s of subs) {
+        words.push(s.name())
+        const alias = s.alias()
+        if (alias) words.push(alias)
+    }
+    for (const o of (cmd.options as Option[]) || []) {
+        if (o.short) words.push(o.short)
+        if (o.long) words.push(o.long)
+    }
+    out.push({ path: currentPath, words })
+
+    for (const s of subs) {
+        collectBashEntries(s, [...currentPath, s.name()], out)
+        const alias = s.alias()
+        if (alias) {
+            collectBashEntries(s, [...currentPath, alias], out)
+        }
+    }
+}
+
+export function generateBashCompletion(program: Command): string {
+    const cliName = program.name()
+    const safeName = cliName.replace(/-/g, '_')
+    const funcName = `_${safeName}`
+
+    const entries: BashEntry[] = []
+    collectBashEntries(program, [], entries)
+
+    const lines: string[] = []
+    lines.push(`# ${cliName} v${program.version()} bash completion`)
+    lines.push(`# Generated automatically - do not edit by hand`)
+    lines.push(``)
+    lines.push(`${funcName}() {`)
+    lines.push(`    local cur path i word completions`)
+    lines.push(`    COMPREPLY=()`)
+    lines.push(`    cur="\${COMP_WORDS[COMP_CWORD]}"`)
+    lines.push(``)
+    lines.push(`    # Build the subcommand path by skipping flags. This is a`)
+    lines.push(`    # simplification: if a flag takes a value, the value word is`)
+    lines.push(`    # also skipped only when it starts with '-', so positional-looking`)
+    lines.push(`    # flag arguments may shift the path. Good enough for most cases.`)
+    lines.push(`    path=""`)
+    lines.push(`    i=1`)
+    lines.push(`    while [ $i -lt $COMP_CWORD ]; do`)
+    lines.push(`        word="\${COMP_WORDS[$i]}"`)
+    lines.push(`        if [[ "$word" == -* ]]; then`)
+    lines.push(`            i=$((i + 1))`)
+    lines.push(`            continue`)
+    lines.push(`        fi`)
+    lines.push(`        if [ -z "$path" ]; then`)
+    lines.push(`            path="$word"`)
+    lines.push(`        else`)
+    lines.push(`            path="$path $word"`)
+    lines.push(`        fi`)
+    lines.push(`        i=$((i + 1))`)
+    lines.push(`    done`)
+    lines.push(``)
+    lines.push(`    completions=""`)
+    lines.push(`    case "$path" in`)
+    for (const entry of entries) {
+        if (entry.words.length === 0) continue
+        const pathStr = escapeBashDq(entry.path.join(' '))
+        const wordsStr = escapeBashDq(entry.words.join(' '))
+        lines.push(`        "${pathStr}")`)
+        lines.push(`            completions="${wordsStr}"`)
+        lines.push(`            ;;`)
+    }
+    lines.push(`    esac`)
+    lines.push(``)
+    lines.push(`    if [ -n "$completions" ]; then`)
+    lines.push(`        # shellcheck disable=SC2207`)
+    lines.push(`        COMPREPLY=( $(compgen -W "$completions" -- "$cur") )`)
+    lines.push(`    fi`)
+    lines.push(`    return 0`)
+    lines.push(`}`)
+    lines.push(``)
+    lines.push(`complete -F ${funcName} ${cliName}`)
+    lines.push(``)
+
+    return lines.join('\n')
+}
+
 export function generateZshCompletion(program: Command): string {
     const cliName = program.name()
     const safeName = cliName.replace(/-/g, '_')
@@ -190,11 +293,11 @@ export default function completion(program: Command): void {
     program
         .command('completion')
         .description('Generate shell completion script')
-        .argument('<shell>', 'Shell type (zsh)')
+        .argument('<shell>', 'Shell type (zsh|bash)')
         .addHelpText(
             'after',
             `
-Setup:
+Setup (zsh):
 
   Option 1 - Add to .zshrc (simplest, slower shell startup):
 
@@ -209,18 +312,35 @@ Setup:
     fpath=(~/.zsh/completions $fpath)
     autoload -Uz compinit && compinit
 
+Setup (bash):
+
+  Option 1 - Add to .bashrc (simplest):
+
+    echo 'eval "$(${cliName} completion bash)"' >> ~/.bashrc
+
+  Option 2 - Source from a cached file:
+
+    mkdir -p ~/.bash_completion.d
+    ${cliName} completion bash > ~/.bash_completion.d/${cliName}
+
+    # Add this line to ~/.bashrc (once):
+    source ~/.bash_completion.d/${cliName}
+
   After upgrading ${cliName}, re-run the command to update completions.
 `
         )
         .action((shell: string) => {
-            if (shell !== 'zsh') {
-                console.error(
-                    `Unsupported shell: ${shell}. Currently only "zsh" is supported.`
-                )
-                process.exit(1)
+            if (shell === 'zsh') {
+                process.stdout.write(generateZshCompletion(program))
+                process.exit(0)
             }
-            const script = generateZshCompletion(program)
-            process.stdout.write(script)
-            process.exit(0)
+            if (shell === 'bash') {
+                process.stdout.write(generateBashCompletion(program))
+                process.exit(0)
+            }
+            console.error(
+                `Unsupported shell: ${shell}. Supported shells: zsh, bash.`
+            )
+            process.exit(1)
         })
 }

--- a/src.ts/cli/completion.ts
+++ b/src.ts/cli/completion.ts
@@ -155,14 +155,15 @@ function escapeBashDq(s: string): string {
         .replace(/`/g, '\\`')
 }
 
+type PathSeg = { name: string; alias?: string }
 type BashEntry = {
-    path: string[]
+    path: PathSeg[]
     words: string[]
 }
 
 function collectBashEntries(
     cmd: Command,
-    currentPath: string[],
+    currentPath: PathSeg[],
     out: BashEntry[]
 ): void {
     const subs = visibleCommands(cmd)
@@ -179,12 +180,29 @@ function collectBashEntries(
     out.push({ path: currentPath, words })
 
     for (const s of subs) {
-        collectBashEntries(s, [...currentPath, s.name()], out)
         const alias = s.alias()
-        if (alias) {
-            collectBashEntries(s, [...currentPath, alias], out)
-        }
+        const seg: PathSeg = alias
+            ? { name: s.name(), alias }
+            : { name: s.name() }
+        collectBashEntries(s, [...currentPath, seg], out)
     }
+}
+
+// Expand an entry's path into every alias combination.
+// e.g. path = [fine-tuning|ft, create-task] → ["fine-tuning create-task", "ft create-task"]
+function expandPathPatterns(path: PathSeg[]): string[] {
+    let patterns: string[] = ['']
+    for (const seg of path) {
+        const choices = seg.alias ? [seg.name, seg.alias] : [seg.name]
+        const next: string[] = []
+        for (const prefix of patterns) {
+            for (const c of choices) {
+                next.push(prefix === '' ? c : `${prefix} ${c}`)
+            }
+        }
+        patterns = next
+    }
+    return patterns
 }
 
 export function generateBashCompletion(program: Command): string {
@@ -228,9 +246,11 @@ export function generateBashCompletion(program: Command): string {
     lines.push(`    case "$path" in`)
     for (const entry of entries) {
         if (entry.words.length === 0) continue
-        const pathStr = escapeBashDq(entry.path.join(' '))
+        const patterns = expandPathPatterns(entry.path)
+            .map((p) => `"${escapeBashDq(p)}"`)
+            .join('|')
         const wordsStr = escapeBashDq(entry.words.join(' '))
-        lines.push(`        "${pathStr}")`)
+        lines.push(`        ${patterns})`)
         lines.push(`            completions="${wordsStr}"`)
         lines.push(`            ;;`)
     }

--- a/src.ts/cli/tips.ts
+++ b/src.ts/cli/tips.ts
@@ -24,8 +24,10 @@ function isInteractive(): boolean {
 function isCompletionInvocation(argv: string[]): boolean {
     // Skip the tip when the user already knows about completion (or when the
     // invocation itself is generating a script that must keep stdout/stderr
-    // clean for `eval`).
-    return argv.slice(2).includes('completion')
+    // clean for `eval`). Match only the first positional arg so user-supplied
+    // values like `inference send --message "completion"` don't suppress it.
+    const firstPositional = argv.slice(2).find((a) => !a.startsWith('-'))
+    return firstPositional === 'completion'
 }
 
 function readSeenTips(): Set<string> {
@@ -56,7 +58,7 @@ function markTipSeen(tip: string, seen: Set<string>): void {
 /**
  * Emits a one-time hint about shell completion the first time the CLI is run
  * in an interactive terminal. Silently skipped in non-TTY / CI contexts, when
- * the user has opted out via 0G_NO_TIPS=1, or when the current invocation is
+ * the user has opted out via ZG_NO_TIPS=1, or when the current invocation is
  * itself the completion command.
  */
 export function showCompletionHintIfNeeded(cliName: string): void {

--- a/src.ts/cli/tips.ts
+++ b/src.ts/cli/tips.ts
@@ -3,7 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import chalk from 'chalk'
 
-const TIPS_DIR = path.join(os.homedir(), '.config', '0g-compute-cli')
+const TIPS_DIR = path.join(os.homedir(), '.0g-compute-cli')
 const TIPS_FILE = path.join(TIPS_DIR, 'tips-seen')
 
 function hasOptedOut(): boolean {

--- a/src.ts/cli/tips.ts
+++ b/src.ts/cli/tips.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import chalk from 'chalk'
+
+const TIPS_DIR = path.join(os.homedir(), '.config', '0g-compute-cli')
+const TIPS_FILE = path.join(TIPS_DIR, 'tips-seen')
+
+function hasOptedOut(): boolean {
+    const optOut = process.env['0G_NO_TIPS'] ?? process.env.ZG_NO_TIPS
+    return optOut === '1' || optOut === 'true'
+}
+
+function isInteractive(): boolean {
+    // Both stdout and stderr should be TTY so the hint reaches a real user and
+    // doesn't contaminate piped output (e.g. `eval "$(... completion zsh)"`).
+    return Boolean(process.stdout.isTTY && process.stderr.isTTY)
+}
+
+function isCompletionInvocation(argv: string[]): boolean {
+    // Skip the tip when the user already knows about completion (or when the
+    // invocation itself is generating a script that must keep stdout/stderr
+    // clean for `eval`).
+    return argv.slice(2).includes('completion')
+}
+
+function readSeenTips(): Set<string> {
+    try {
+        const raw = fs.readFileSync(TIPS_FILE, 'utf8')
+        return new Set(
+            raw
+                .split('\n')
+                .map((l) => l.trim())
+                .filter(Boolean)
+        )
+    } catch {
+        return new Set()
+    }
+}
+
+function markTipSeen(tip: string, seen: Set<string>): void {
+    try {
+        seen.add(tip)
+        fs.mkdirSync(TIPS_DIR, { recursive: true })
+        fs.writeFileSync(TIPS_FILE, Array.from(seen).join('\n') + '\n')
+    } catch {
+        // Non-fatal: we just won't persist the flag this run. The hint may
+        // appear again, which is acceptable.
+    }
+}
+
+/**
+ * Emits a one-time hint about shell completion the first time the CLI is run
+ * in an interactive terminal. Silently skipped in non-TTY / CI contexts, when
+ * the user has opted out via 0G_NO_TIPS=1, or when the current invocation is
+ * itself the completion command.
+ */
+export function showCompletionHintIfNeeded(cliName: string): void {
+    if (hasOptedOut()) return
+    if (!isInteractive()) return
+    if (isCompletionInvocation(process.argv)) return
+
+    const seen = readSeenTips()
+    if (seen.has('completion')) return
+
+    process.stderr.write(
+        `\n${chalk.cyan('Tip:')} Enable shell completion (zsh/bash) with ` +
+            `\`${cliName} completion --help\`.\n` +
+            `     Set 0G_NO_TIPS=1 to silence future hints.\n\n`
+    )
+
+    markTipSeen('completion', seen)
+}

--- a/src.ts/cli/tips.ts
+++ b/src.ts/cli/tips.ts
@@ -7,7 +7,11 @@ const TIPS_DIR = path.join(os.homedir(), '.0g-compute-cli')
 const TIPS_FILE = path.join(TIPS_DIR, 'tips-seen')
 
 function hasOptedOut(): boolean {
-    const optOut = process.env['0G_NO_TIPS'] ?? process.env.ZG_NO_TIPS
+    // ZG_NO_TIPS is the documented name (POSIX-compatible). 0G_NO_TIPS is kept
+    // as an undocumented fallback — shells reject identifiers starting with a
+    // digit in `VAR=value cmd` / `export VAR=...`, so it can only be set via
+    // tools like `env` and isn't something we want to point users at.
+    const optOut = process.env.ZG_NO_TIPS ?? process.env['0G_NO_TIPS']
     return optOut === '1' || optOut === 'true'
 }
 
@@ -66,7 +70,7 @@ export function showCompletionHintIfNeeded(cliName: string): void {
     process.stderr.write(
         `\n${chalk.cyan('Tip:')} Enable shell completion (zsh/bash) with ` +
             `\`${cliName} completion --help\`.\n` +
-            `     Set 0G_NO_TIPS=1 to silence future hints.\n\n`
+            `     Set ZG_NO_TIPS=1 to silence future hints.\n\n`
     )
 
     markTipSeen('completion', seen)


### PR DESCRIPTION
## Summary
This PR adds bash shell completion support to the CLI and introduces a one-time hint to users about the completion feature.

## Key Changes

- **Bash completion generation**: Implemented `generateBashCompletion()` function that generates a bash completion script with support for subcommands, aliases, and options
  - Added `escapeBashDq()` helper to properly escape special characters in bash double-quoted strings
  - Added `collectBashEntries()` to recursively traverse the command tree and collect completion words for each command path
  - Generates a bash function using case statements to provide context-aware completions

- **Completion hint system**: Created new `tips.ts` module that shows a one-time hint about shell completion
  - Displays hint only in interactive TTY environments
  - Respects `0G_NO_TIPS` environment variable to allow users to opt out
  - Skips hint during completion invocations to keep stdout/stderr clean for `eval` usage
  - Persists seen tips in `~/.0g-compute-cli/tips-seen` file

- **Updated completion command**: Modified the completion subcommand to support both zsh and bash
  - Changed argument description from `'Shell type (zsh)'` to `'Shell type (zsh|bash)'`
  - Updated help text with separate setup instructions for bash and zsh
  - Refactored action handler to explicitly check for supported shells

- **Integration**: Added call to `showCompletionHintIfNeeded()` in the main CLI initialization

## Implementation Details

The bash completion script uses a case statement to match the current command path and provide appropriate completions. It handles flag skipping to build the subcommand path, though with the noted simplification that flag values starting with '-' won't shift the path.

The tips system is non-blocking and gracefully handles file system errors to avoid disrupting CLI usage.

https://claude.ai/code/session_01Dmkj16iF2eytJJVoXS99o1