### PR TITLE
chore: deprecation notice for upcoming package rename (v0.7.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 0G Compute Network SDK
 
+> ⚠️ **DEPRECATION NOTICE**: This package will be renamed from `@0glabs/0g-serving-broker` to **`@0gfoundation/0g-compute-ts-sdk`** starting from **v0.8.0**.
+> Please migrate your `package.json` dependency and imports. The current `@0glabs/0g-serving-broker` package will continue to work as a thin re-export of the new package for one additional patch release, but will not receive further updates.
+
 Access decentralized AI computing through the 0G Compute Network - a GPU marketplace that connects developers with affordable AI inference and fine-tuning services.
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0glabs/0g-serving-broker",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {

--- a/src.ts/cli/cli.ts
+++ b/src.ts/cli/cli.ts
@@ -16,7 +16,7 @@ export const program = new Command()
 program
     .name('0g-compute-cli')
     .description('CLI for interacting with ZG Compute Network')
-    .version('0.7.5')
+    .version('0.7.6')
 
 ledger(program)
 
@@ -115,6 +115,11 @@ function showUpdateNotification(updateInfo: {
     } catch {
         // Silently fail - don't block CLI usage (e.g., in Yarn PnP environments)
     }
+
+    process.stderr.write(
+        '\n⚠️  DEPRECATION NOTICE: "@0glabs/0g-serving-broker" will be renamed to "@0gfoundation/0g-compute-ts-sdk" in v0.8.0.\n' +
+            '   Please migrate your dependency. See https://github.com/0glabs/0g-serving-user-broker for details.\n\n'
+    )
 
     program.parse(process.argv)
 })()

--- a/src.ts/sdk/broker.ts
+++ b/src.ts/sdk/broker.ts
@@ -29,6 +29,16 @@ export {
     getNetworkType,
 }
 
+let deprecationWarningShown = false
+function showDeprecationWarning(): void {
+    if (deprecationWarningShown) return
+    deprecationWarningShown = true
+    console.warn(
+        '\n⚠️  DEPRECATION NOTICE: The npm package "@0glabs/0g-serving-broker" will be renamed to "@0gfoundation/0g-compute-ts-sdk" starting from v0.8.0.\n' +
+            '   Please migrate by updating your dependency and imports. See https://github.com/0glabs/0g-serving-user-broker for details.\n'
+    )
+}
+
 export class ZGComputeNetworkBroker {
     public ledger!: LedgerBroker
     public inference!: InferenceBroker
@@ -72,6 +82,7 @@ export async function createZGComputeNetworkBroker(
     maxGasPrice?: number,
     step?: number
 ): Promise<ZGComputeNetworkBroker> {
+    showDeprecationWarning()
     try {
         // Auto-detect network from signer's provider
         let defaultAddresses: {
@@ -213,6 +224,7 @@ export async function createZGComputeNetworkReadOnlyBroker(
     rpcUrl: string,
     chainId?: number
 ): Promise<ZGComputeNetworkReadOnlyBroker> {
+    showDeprecationWarning()
     try {
         // Create provider to detect network if chainId not provided
         let detectedChainId = chainId


### PR DESCRIPTION
## Summary

This PR is **Step 1 of a 3-step package rename plan**: `@0glabs/0g-serving-broker` → `@0gfoundation/0g-compute-ts-sdk`.

It does **not** rename anything yet. It only adds **deprecation warnings** so existing users hear about the rename before v0.8.0 lands.

### Changes
- `package.json`: bump `0.7.5` → `0.7.6`
- `README.md`: add deprecation banner under the title
- `src.ts/sdk/broker.ts`: print a one-time `console.warn` from `createZGComputeNetworkBroker` and `createZGComputeNetworkReadOnlyBroker` (gated by a module-level flag so it fires at most once per process)
- `src.ts/cli/cli.ts`: print a stderr deprecation notice on every CLI invocation, and bump the hardcoded `--version` literal to match

## Rollout plan (for context — not in this PR)

| Step | Version | Package name | What |
|---|---|---|---|
| **1 (this PR)** | `0.7.6` | `@0glabs/0g-serving-broker` | Add deprecation warnings |
| 2 (next PR) | `0.8.0` | `@0gfoundation/0g-compute-ts-sdk` | Actual rename + update all internal references |
| 3 (final PR) | `0.7.7` | `@0glabs/0g-serving-broker` | Stub package — depends on the new package and re-exports it; runs `npm deprecate` after publish |

GitHub releases will be published for each version to keep the npm versions and repo releases in sync.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Manual: `node -e "require('./lib.commonjs').createZGComputeNetworkBroker(...)"` shows the deprecation warning once
- [ ] Manual: running the CLI prints the deprecation notice on stderr
- [ ] `npm run test` passes
- [ ] README banner renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)