### PR TITLE
chore: add legacy stub package @0glabs/0g-serving-broker@0.7.7

### DIFF
--- a/stub/README.md
+++ b/stub/README.md
@@ -1,0 +1,37 @@
+# @0glabs/0g-serving-broker — DEPRECATED
+
+> 📦 **This package has been renamed to [`@0gfoundation/0g-compute-ts-sdk`](https://www.npmjs.com/package/@0gfoundation/0g-compute-ts-sdk).**
+>
+> This `0.7.7` release is a thin re-export shim that depends on `@0gfoundation/0g-compute-ts-sdk@^0.8.0`. Existing code keeps working, but **please migrate** — this package will not receive further updates.
+
+## Migration
+
+Update your dependency:
+
+```bash
+npm uninstall @0glabs/0g-serving-broker
+npm install @0gfoundation/0g-compute-ts-sdk
+```
+
+Update your imports:
+
+```diff
+- import { createZGComputeNetworkBroker } from '@0glabs/0g-serving-broker'
++ import { createZGComputeNetworkBroker } from '@0gfoundation/0g-compute-ts-sdk'
+```
+
+Or run this one-liner from your project root:
+
+```bash
+grep -rl --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' \
+    '@0glabs/0g-serving-broker' . \
+  | xargs sed -i 's|@0glabs/0g-serving-broker|@0gfoundation/0g-compute-ts-sdk|g'
+```
+
+The public API is unchanged — only the package name moved.
+
+## Links
+
+- New package: <https://www.npmjs.com/package/@0gfoundation/0g-compute-ts-sdk>
+- Source / docs: <https://github.com/0gfoundation/0g-serving-user-broker>
+- Issues: <https://github.com/0gfoundation/0g-serving-user-broker/issues>

--- a/stub/index.d.ts
+++ b/stub/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@0gfoundation/0g-compute-ts-sdk'

--- a/stub/index.js
+++ b/stub/index.js
@@ -1,0 +1,1 @@
+module.exports = require('@0gfoundation/0g-compute-ts-sdk')

--- a/stub/index.mjs
+++ b/stub/index.mjs
@@ -1,0 +1,1 @@
+export * from '@0gfoundation/0g-compute-ts-sdk'

--- a/stub/package.json
+++ b/stub/package.json
@@ -1,0 +1,39 @@
+{
+    "name": "@0glabs/0g-serving-broker",
+    "version": "0.7.7",
+    "description": "DEPRECATED — renamed to @0gfoundation/0g-compute-ts-sdk. This package is a thin re-export shim for backward compatibility.",
+    "main": "./index.js",
+    "module": "./index.mjs",
+    "types": "./index.d.ts",
+    "exports": {
+        "types": "./index.d.ts",
+        "require": "./index.js",
+        "import": "./index.mjs"
+    },
+    "files": [
+        "index.js",
+        "index.mjs",
+        "index.d.ts",
+        "README.md"
+    ],
+    "engines": {
+        "node": ">=20.0.0"
+    },
+    "dependencies": {
+        "@0gfoundation/0g-compute-ts-sdk": "^0.8.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "license": "ISC",
+    "author": "0G Labs",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/0gfoundation/0g-serving-user-broker.git",
+        "directory": "stub"
+    },
+    "homepage": "https://github.com/0gfoundation/0g-serving-user-broker#readme",
+    "bugs": {
+        "url": "https://github.com/0gfoundation/0g-serving-user-broker/issues"
+    }
+}


### PR DESCRIPTION
## Summary

**Step 3 (final step) of the package rename.** Adds a `stub/` subdirectory containing a minimal package that gets published as `@0glabs/0g-serving-broker@0.7.7` — a thin re-export shim pointing at `@0gfoundation/0g-compute-ts-sdk@^0.8.0`.

### Why a stub (and not just deprecation)

The old package was already deprecated on npm, but users with `@0glabs/0g-serving-broker` pinned in `package.json` (or pulled in transitively) currently freeze on 0.7.6 forever — they never receive 0.8.x bug fixes via `npm update`. The stub provides a redirect: \`npm update\` brings them to 0.7.7, which transitively depends on `^0.8.0`, so they automatically pick up new code while still seeing the deprecation banner.

### Files added

```
stub/
├── package.json    # name: @0glabs/0g-serving-broker, version: 0.7.7
│                   # deps: @0gfoundation/0g-compute-ts-sdk@^0.8.0
│                   # publishConfig.access: public
├── index.js        # CJS:  module.exports = require('@0gfoundation/0g-compute-ts-sdk')
├── index.mjs       # ESM:  export * from '@0gfoundation/0g-compute-ts-sdk'
├── index.d.ts      # type: export * from '@0gfoundation/0g-compute-ts-sdk'
└── README.md       # Pure migration notice (replaces npm page content)
```

Verified locally that `require('./index.js')` resolves to the real exports of `@0gfoundation/0g-compute-ts-sdk` (e.g. `createZGComputeNetworkBroker`, `InferenceBroker`, etc.).

### Scope notes

- **No CLI bin** in the stub. Users who installed the CLI globally (`npm install -g @0glabs/0g-serving-broker`) keep their working 0.7.6 CLI; they should reinstall via `npm install -g @0gfoundation/0g-compute-ts-sdk` to get 0.8.x. The stub is a library-only redirect, matching the standard pattern recommended by colleagues.
- The stub does not need to repeat `peerDependencies` — they cascade through the dependency on the new package.

## Publish flow (after merge)

```bash
cd stub
npm install                                    # populate node_modules so tarball is valid (no-op effectively)
npm publish --access public --otp=<6-digit>    # publishes @0glabs/0g-serving-broker@0.7.7

# Re-tighten deprecation to exclude 0.7.7 itself, so installing the stub
# does NOT show "deprecated" on the redirect package
npm deprecate '@0glabs/0g-serving-broker@<0.7.7' \
  "Renamed to @0gfoundation/0g-compute-ts-sdk. Run: npm i @0gfoundation/0g-compute-ts-sdk and remove @0glabs/0g-serving-broker"

# (Optional) confirm
npm view @0glabs/0g-serving-broker
```

Then create GitHub release `v0.7.7-stub` (or just `v0.7.7`, matching the npm version convention).

## Rollout summary

| Step | Version | Package | Status |
|---|---|---|---|
| 1 | `0.7.6` | `@0glabs/0g-serving-broker` | ✅ npm + release |
| 2 | `0.8.0` | `@0gfoundation/0g-compute-ts-sdk` | ✅ npm + release |
| **3 (this PR)** | `0.7.7` | `@0glabs/0g-serving-broker` (stub) | 🟡 awaiting review |

## Test plan

- [ ] Reviewer can `cd stub && npm install && node -e "console.log(Object.keys(require('./index.js')).slice(0, 5))"` and see real exports
- [ ] Reviewer confirms `stub/package.json` has `publishConfig.access: public` (avoids the 402 error we hit on the new scope)
- [ ] After merge: publish from `stub/` and verify on npmjs.com that the stub page shows the migration README and resolves correctly
- [ ] After publish: re-run `npm deprecate` with the `<0.7.7` range so the stub itself is not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)