### PR TITLE
chore: add CLI bin to legacy stub (v0.7.8)

### DIFF
--- a/stub/cli.js
+++ b/stub/cli.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const path = require('path')
+
+// Resolve the new package's entry point, walk up to the package root,
+// then load its CLI directly. This avoids the new package's `exports`
+// field blocking subpath imports.
+const entryPath = require.resolve('@0gfoundation/0g-compute-ts-sdk')
+const pkgRoot = path.resolve(path.dirname(entryPath), '..')
+require(path.join(pkgRoot, 'cli.commonjs', 'cli', 'index.js'))

--- a/stub/package.json
+++ b/stub/package.json
@@ -1,10 +1,13 @@
 {
     "name": "@0glabs/0g-serving-broker",
-    "version": "0.7.7",
+    "version": "0.7.8",
     "description": "DEPRECATED — renamed to @0gfoundation/0g-compute-ts-sdk. This package is a thin re-export shim for backward compatibility.",
     "main": "./index.js",
     "module": "./index.mjs",
     "types": "./index.d.ts",
+    "bin": {
+        "0g-compute-cli": "./cli.js"
+    },
     "exports": {
         "types": "./index.d.ts",
         "require": "./index.js",
@@ -14,6 +17,7 @@
         "index.js",
         "index.mjs",
         "index.d.ts",
+        "cli.js",
         "README.md"
     ],
     "engines": {

--- a/web-ui/pnpm-lock.yaml
+++ b/web-ui/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
 
   .:
     dependencies:
-      '@0glabs/0g-serving-broker':
+      '@0gfoundation/0g-compute-ts-sdk':
         specifier: file:..
         version: file:..(@types/circomlibjs@0.1.6)(@types/crypto-js@4.2.2)(circomlibjs@0.1.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(crypto-js@4.2.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@radix-ui/react-alert-dialog':
@@ -191,7 +191,7 @@ importers:
 
 packages:
 
-  '@0glabs/0g-serving-broker@file:..':
+  '@0gfoundation/0g-compute-ts-sdk@file:..':
     resolution: {directory: .., type: directory}
     engines: {node: '>=20.0.0'}
     hasBin: true
@@ -5358,7 +5358,7 @@ packages:
 
 snapshots:
 
-  '@0glabs/0g-serving-broker@file:..(@types/circomlibjs@0.1.6)(@types/crypto-js@4.2.2)(circomlibjs@0.1.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(crypto-js@4.2.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@0gfoundation/0g-compute-ts-sdk@file:..(@types/circomlibjs@0.1.6)(@types/crypto-js@4.2.2)(circomlibjs@0.1.7(bufferutil@4.1.0)(utf-8-validate@5.0.10))(crypto-js@4.2.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/keccak256': 5.8.0


### PR DESCRIPTION
## Summary

fix for the `@0glabs/0g-serving-broker@0.7.7` stub published in #204. That release shipped without a `bin` entry, which broke users who installed the old package globally for the CLI:

```
$ pnpm add -g @0glabs/0g-serving-broker
WARN @0glabs/0g-serving-broker has no binaries

$ 0g-compute-cli --version
zsh: command not found: 0g-compute-cli
```

This PR re-introduces the CLI by adding a thin shim that loads the new package's CLI module directly.

## Changes

- `stub/cli.js` (**new**): one-liner that resolves `@0gfoundation/0g-compute-ts-sdk` and `require()`s its `cli.commonjs/cli/index.js`. Walks up from the entry point to package root rather than using a subpath import, because the new package's `exports` field would block direct subpath access.
- `stub/package.json`:
  - bump `0.7.7` → `0.7.8`
  - add `"bin": { "0g-compute-cli": "./cli.js" }`
  - add `cli.js` to `files`

## Verification

Locally installed the stub's deps and ran the shim — confirms it dispatches to the renamed package's CLI:

```
$ cd stub && npm install
$ node cli.js --version
0.8.0
```

`0.8.0` is the version reported by the new package's CLI, proving the shim correctly delegates.

## Migration for users on 0.7.7

```bash
pnpm update -g @0glabs/0g-serving-broker     # picks up 0.7.8 with bin
0g-compute-cli --version                      # prints 0.8.0
```

Or, equivalently, install the new package directly:

```bash
pnpm add -g @0gfoundation/0g-compute-ts-sdk
```

## Publish flow (after merge)

```bash
cd stub
npm publish --access public --otp=<6-digit>

# No need to re-run npm deprecate — the existing range
# '@0glabs/0g-serving-broker@<0.7.7' already excludes 0.7.8
# (since 0.7.8 > 0.7.7, it's outside the deprecated range).
# Verify with: npm view @0glabs/0g-serving-broker
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)