### PR TITLE
fix(fine-tuning): address May 2026 hackathon bug report (Bug #1, #2, #4, #5)

### DIFF
--- a/Interface.md
+++ b/Interface.md
@@ -39,6 +39,17 @@
     2. decrypt the encryptedSecret
     3. decrypt model with secret [TODO: Discuss LiuYuan]
 
+> **Note:** `acknowledgeModel` (step 10) is the only correct retrieval entry
+> point for the normal happy path — it downloads, verifies, and acknowledges
+> in one call. The lower-level `downloadModelFrom0GStorage` and `decryptModel`
+> helpers are kept for advanced flows but **do not** acknowledge the
+> deliverable on-chain. Forgetting the acknowledgement permanently locks
+> the user's task queue ("previous deliverable not acknowledged" revert on
+> the next `addDeliverable`). If the artifact is no longer retrievable, use
+> the escape hatch `acknowledgeDeliverable(provider, taskId)` (or the CLI
+> command `0g-compute-cli fine-tuning acknowledge-deliverable`) to release
+> the queue without artifact download.
+
 ### Code Structure
 
 #### util

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,6 +5,26 @@ import dts from 'rollup-plugin-dts'
 import json from '@rollup/plugin-json'
 import nodePolyfills from 'rollup-plugin-polyfill-node'
 
+// Inject a Node-compatible `__dirname` (and `__filename`) shim at the top of
+// the ESM bundle. Without this, `__dirname` is undefined inside `lib.esm/
+// index.mjs`, which breaks `binary-path.ts`'s anchor resolution for any
+// downstream ESM consumer (the fallback to `process.cwd()` walks **upward**
+// from the consumer's project root and never finds the
+// `node_modules/@0gfoundation/0g-compute-ts-sdk/binary/` directory below it).
+//
+// This restores parity with the CommonJS build, where Node injects
+// `__dirname` per module. With the shim, the anchor lands inside the
+// installed package (`<pkg>/lib.esm/`) and `findAncestorContaining`
+// correctly resolves `<pkg>/binary/` one level up.
+//
+// See PR #208 review feedback (Bug Report — May 2026, Bug #1).
+const esmDirnameShim = [
+    "import { fileURLToPath as __zg_fileURLToPath } from 'url'",
+    "import { dirname as __zg_dirname } from 'path'",
+    'const __filename = __zg_fileURLToPath(import.meta.url)',
+    'const __dirname = __zg_dirname(__filename)',
+].join('\n')
+
 export default [
     {
         input: 'src.ts/sdk/index.ts',
@@ -13,22 +33,34 @@ export default [
             format: 'esm',
             sourcemap: true,
             entryFileNames: 'index.mjs',
+            banner: esmDirnameShim,
         },
         plugins: [
             json(),
             resolve({
                 browser: true,
-                preferBuiltins: false
+                preferBuiltins: false,
             }),
             commonjs(),
             nodePolyfills({
-                include: ['crypto', 'stream', 'util', 'buffer']
+                include: ['crypto', 'stream', 'util', 'buffer'],
             }),
             typescript({
                 tsconfig: './tsconfig.esm.json',
             }),
         ],
-        external: ['ethers', 'crypto-js', 'circomlibjs', 'child_process', 'fs', 'fs/promises', 'path', 'os', 'crypto', 'readline'],
+        external: [
+            'ethers',
+            'crypto-js',
+            'circomlibjs',
+            'child_process',
+            'fs',
+            'fs/promises',
+            'path',
+            'os',
+            'crypto',
+            'readline',
+        ],
     },
     {
         input: 'lib.esm/index.d.ts',

--- a/src.ts/cli/fine-tuning.ts
+++ b/src.ts/cli/fine-tuning.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env ts-node
 
 import type { Command } from 'commander'
-import { withFineTuningBroker, withBroker, withROBroker, neuronToA0gi, splitIntoChunks } from './util'
+import {
+    withFineTuningBroker,
+    withBroker,
+    withROBroker,
+    neuronToA0gi,
+    splitIntoChunks,
+} from './util'
 import Table from 'cli-table3'
 import chalk from 'chalk'
 import { ZG_RPC_ENDPOINT_TESTNET } from './const'
@@ -171,7 +177,9 @@ export default function fineTuning(program: Command) {
 
     program
         .command('calculate-token')
-        .description('Calculate token count (optional - for cost estimation only, no longer required for task creation)')
+        .description(
+            'Calculate token count (optional - for cost estimation only, no longer required for task creation)'
+        )
         .requiredOption('--model <name>', 'Pre-trained model name to use')
         .requiredOption(
             '--dataset-path <path>',
@@ -191,7 +199,9 @@ export default function fineTuning(program: Command) {
 
     program
         .command('create-task')
-        .description('Create a fine-tuning task (fee calculated automatically by broker)')
+        .description(
+            'Create a fine-tuning task (fee calculated automatically by broker)'
+        )
         .requiredOption('--provider <address>', 'Provider address for the task')
         .requiredOption('--model <name>', 'Pre-trained model name to use')
         .option('--dataset <hash>', 'Hash of the dataset (from 0G Storage)')
@@ -242,19 +252,32 @@ export default function fineTuning(program: Command) {
                         )
                         if (rootHash) {
                             datasetHash = rootHash
-                            console.log('Dataset uploaded to 0G Storage, root hash:', datasetHash)
+                            console.log(
+                                'Dataset uploaded to 0G Storage, root hash:',
+                                datasetHash
+                            )
                         } else {
-                            throw new Error('Upload succeeded but no root hash returned')
+                            throw new Error(
+                                'Upload succeeded but no root hash returned'
+                            )
                         }
                     } catch (storageErr) {
-                        console.warn(chalk.yellow(`\n⚠️  0G Storage upload failed: ${storageErr}`))
-                        console.log('Falling back to direct TEE upload...')
-                        const result = await broker.fineTuning!.uploadDatasetToTEE(
-                            options.provider,
-                            options.datasetPath
+                        console.warn(
+                            chalk.yellow(
+                                `\n⚠️  0G Storage upload failed: ${storageErr}`
+                            )
                         )
+                        console.log('Falling back to direct TEE upload...')
+                        const result =
+                            await broker.fineTuning!.uploadDatasetToTEE(
+                                options.provider,
+                                options.datasetPath
+                            )
                         datasetHash = result.datasetHash
-                        console.log('Dataset uploaded to TEE (fallback), hash:', datasetHash)
+                        console.log(
+                            'Dataset uploaded to TEE (fallback), hash:',
+                            datasetHash
+                        )
                     }
                 }
 
@@ -267,21 +290,38 @@ export default function fineTuning(program: Command) {
 
                 // Check account balance and warn if insufficient
                 try {
-                    const accountDetail = await broker.fineTuning!.getAccountWithDetail(
-                        options.provider
-                    )
-                    const availableBalance = accountDetail.account.balance - accountDetail.account.pendingRefund
+                    const accountDetail =
+                        await broker.fineTuning!.getAccountWithDetail(
+                            options.provider
+                        )
+                    const availableBalance =
+                        accountDetail.account.balance -
+                        accountDetail.account.pendingRefund
 
                     if (availableBalance <= BigInt(0)) {
-                        console.warn(chalk.yellow('\n⚠️  Warning: Your fine-tuning account balance is 0 or negative'))
-                        console.warn(chalk.yellow('   Please deposit funds before creating a task:'))
-                        console.warn(chalk.cyan(`   0g-compute-cli transfer-fund --provider ${options.provider} --service fine-tuning --amount <amount>\n`))
+                        console.warn(
+                            chalk.yellow(
+                                '\n⚠️  Warning: Your fine-tuning account balance is 0 or negative'
+                            )
+                        )
+                        console.warn(
+                            chalk.yellow(
+                                '   Please deposit funds before creating a task:'
+                            )
+                        )
+                        console.warn(
+                            chalk.cyan(
+                                `   0g-compute-cli transfer-fund --provider ${options.provider} --service fine-tuning --amount <amount>\n`
+                            )
+                        )
                     }
                 } catch (err) {
                     // Ignore balance check errors, proceed with task creation
                 }
 
-                console.log('Creating task (fee will be calculated automatically)...')
+                console.log(
+                    'Creating task (fee will be calculated automatically)...'
+                )
                 const taskId = await broker.fineTuning!.createTask(
                     options.provider,
                     options.model,
@@ -419,6 +459,10 @@ export default function fineTuning(program: Command) {
             'Base model name (required when using --deploy, e.g. Qwen2.5-0.5B-Instruct)'
         )
         .option(
+            '--inference-provider <address>',
+            'Inference provider address for --deploy (defaults to --provider if not specified)'
+        )
+        .option(
             '--deploy',
             'Also deploy the adapter to the inference GPU after acknowledging',
             false
@@ -426,9 +470,7 @@ export default function fineTuning(program: Command) {
         .action((options) => {
             if (options.deploy && !options.model) {
                 console.error(
-                    chalk.red(
-                        'Error: --model is required when using --deploy'
-                    )
+                    chalk.red('Error: --model is required when using --deploy')
                 )
                 process.exit(1)
             }
@@ -440,28 +482,62 @@ export default function fineTuning(program: Command) {
                     options.dataPath,
                     {
                         gasPrice: options.gasPrice,
-                        downloadMethod: (options.downloadMethod as
-                            | 'tee'
-                            | '0g-storage'
-                            | 'auto'
-                            | undefined) ?? 'auto',
+                        downloadMethod:
+                            (options.downloadMethod as
+                                | 'tee'
+                                | '0g-storage'
+                                | 'auto'
+                                | undefined) ?? 'auto',
                     }
                 )
                 console.log('Acknowledged model')
 
                 if (options.deploy) {
+                    const inferenceProvider =
+                        options.inferenceProvider || options.provider
                     console.log(
                         '\nWaiting for inference broker to download the adapter...'
                     )
                     await deployAdapterToBroker(
                         broker,
-                        options.provider,
+                        inferenceProvider,
                         options.model,
                         options.taskId,
                         true,
                         180
                     )
                 }
+            })
+        })
+
+    program
+        .command('acknowledge-deliverable')
+        .description(
+            'Acknowledge a delivered task on-chain WITHOUT downloading the model. ' +
+                'Escape hatch for unblocking a locked deliverable queue (see Bug #4 ' +
+                'in the May 2026 hackathon report). Prefer `acknowledge-model` for ' +
+                'the normal happy path.'
+        )
+        .requiredOption('--provider <address>', 'Provider address')
+        .requiredOption('--task-id <id>', 'Task ID to acknowledge')
+        .option('--rpc <url>', '0G Chain RPC endpoint')
+        .option('--ledger-ca <address>', 'Account (ledger) contract address')
+        .option('--inference-ca <address>', 'Inference contract address')
+        .option('--fine-tuning-ca <address>', 'Fine Tuning contract address')
+        .option('--gas-price <price>', 'Gas price for transactions')
+        .option('--max-gas-price <price>', 'Max gas price for transactions')
+        .option('--step <step>', 'Step for gas price adjustment')
+        .action((options) => {
+            withFineTuningBroker(options, async (broker) => {
+                await broker.fineTuning!.acknowledgeDeliverable(
+                    options.provider,
+                    options.taskId,
+                    options.gasPrice
+                )
+                console.log(
+                    `Acknowledged deliverable for task ${options.taskId}. ` +
+                        'Note: no model hash was verified by this call.'
+                )
             })
         })
 
@@ -623,10 +699,7 @@ export default function fineTuning(program: Command) {
         .description(
             'Deploy a downloaded LoRA adapter to the inference GPU (triggers vLLM loading)'
         )
-        .requiredOption(
-            '--provider <address>',
-            'Inference provider address'
-        )
+        .requiredOption('--provider <address>', 'Inference provider address')
         .option(
             '--adapter-name <name>',
             'LoRA adapter name (overrides --model + --task-id)'
@@ -714,10 +787,7 @@ export default function fineTuning(program: Command) {
             if (options.adapterName) {
                 adapterName = options.adapterName
             } else if (options.model && options.taskId) {
-                adapterName = makeAdapterName(
-                    options.model,
-                    options.taskId
-                )
+                adapterName = makeAdapterName(options.model, options.taskId)
             } else {
                 console.error(
                     chalk.red(
@@ -736,9 +806,7 @@ export default function fineTuning(program: Command) {
                     )
                 }
 
-                console.log(
-                    chalk.gray(`Adapter model name: ${adapterName}`)
-                )
+                console.log(chalk.gray(`Adapter model name: ${adapterName}`))
 
                 const resp = await broker.inference.chatWithFineTunedModel(
                     options.provider,
@@ -773,7 +841,11 @@ async function deployAdapterToBroker(
                 providerAddress: string,
                 baseModel: string,
                 taskId: string,
-                options?: { wait?: boolean; timeoutSeconds?: number; onProgress?: (state: string) => void }
+                options?: {
+                    wait?: boolean
+                    timeoutSeconds?: number
+                    onProgress?: (state: string) => void
+                }
             ) => Promise<{ message: string; adapterName?: string }>
             resolveAdapterName: (
                 providerAddress: string,
@@ -817,7 +889,11 @@ async function deployAdapterByName(
             deployAdapterByName: (
                 providerAddress: string,
                 adapterName: string,
-                options?: { wait?: boolean; timeoutSeconds?: number; onProgress?: (state: string) => void }
+                options?: {
+                    wait?: boolean
+                    timeoutSeconds?: number
+                    onProgress?: (state: string) => void
+                }
             ) => Promise<{ message: string; adapterName?: string }>
         }
     },

--- a/src.ts/sdk/fine-tuning/broker/broker.ts
+++ b/src.ts/sdk/fine-tuning/broker/broker.ts
@@ -312,6 +312,39 @@ export class FineTuningBroker extends ReadOnlyFineTuningBroker {
     }
 
     /**
+     * Acknowledge a delivered task on-chain *without* downloading the model.
+     *
+     * Escape hatch for the May 2026 hackathon bug report's Bug #4. If a
+     * user retrieved the artifact through some out-of-band path (e.g. the
+     * legacy `downloadModelFrom0GStorage` + `decryptModel` two-step) and
+     * then never called `acknowledgeModel`, every subsequent
+     * `addDeliverable` for the same `(user, provider)` pair will revert
+     * on-chain with "previous deliverable not acknowledged". After the
+     * artifact is garbage-collected from both 0G Storage and TEE buffers,
+     * `acknowledgeModel` itself can no longer succeed. Calling
+     * `acknowledgeDeliverable(provider, taskId)` directly releases the
+     * queue without requiring artifact retrieval.
+     *
+     * For the normal happy path always prefer {@link FineTuningBroker.acknowledgeModel}
+     * — it downloads, verifies the model hash, and acks in one step.
+     */
+    public acknowledgeDeliverable = async (
+        providerAddress: string,
+        taskId: string,
+        gasPrice?: number
+    ): Promise<void> => {
+        try {
+            return await this.modelProcessor.acknowledgeDeliverable(
+                providerAddress,
+                taskId,
+                gasPrice
+            )
+        } catch (error) {
+            throwFormattedError(error)
+        }
+    }
+
+    /**
      * Download LoRA model directly from TEE
      */
     public downloadLoRAFromTEE = async (
@@ -350,7 +383,19 @@ export class FineTuningBroker extends ReadOnlyFineTuningBroker {
     }
 
     /**
-     * Download encrypted model from 0G Storage (for advanced use cases)
+     * Download encrypted model from 0G Storage (for advanced use cases).
+     *
+     * @deprecated Prefer {@link FineTuningBroker.acknowledgeModel}, which
+     * downloads, verifies the on-chain model hash, and acknowledges the
+     * deliverable in a single call. Calling this method on its own leaves
+     * the deliverable in an unacknowledged state on-chain — every
+     * subsequent `addDeliverable` for the same `(user, provider)` pair will
+     * then revert with "previous deliverable not acknowledged",
+     * permanently locking the user's task queue. This is the trigger for
+     * Bug #4 in the May 2026 hackathon report. If you must use this
+     * advanced path, ensure you call
+     * {@link FineTuningBroker.acknowledgeDeliverable} (or
+     * {@link FineTuningBroker.acknowledgeModel}) afterwards.
      */
     public downloadModelFrom0GStorage = async (
         providerAddress: string,
@@ -368,6 +413,18 @@ export class FineTuningBroker extends ReadOnlyFineTuningBroker {
         }
     }
 
+    /**
+     * Decrypt an already-downloaded encrypted model artifact.
+     *
+     * @deprecated Prefer {@link FineTuningBroker.acknowledgeModel}; that
+     * call downloads, verifies, and acks in one go and never leaves the
+     * deliverable in an unacknowledged state. Using `decryptModel` as the
+     * second half of the legacy two-step pattern (after
+     * `downloadModelFrom0GStorage`) does **not** acknowledge the
+     * deliverable on-chain — see {@link FineTuningBroker.downloadModelFrom0GStorage}
+     * for the queue-locking failure mode this caused in the May 2026 bug
+     * report (Bug #4).
+     */
     public decryptModel = async (
         providerAddress: string,
         taskId: string,
@@ -430,7 +487,11 @@ export class FineTuningBroker extends ReadOnlyFineTuningBroker {
         onLog?: (step: VerificationStep) => void
     ): Promise<VerificationResult> => {
         try {
-            return await this.verifier.verifyService(providerAddress, outputDir, onLog)
+            return await this.verifier.verifyService(
+                providerAddress,
+                outputDir,
+                onLog
+            )
         } catch (error) {
             throwFormattedError(error)
         }

--- a/src.ts/sdk/fine-tuning/broker/broker.ts
+++ b/src.ts/sdk/fine-tuning/broker/broker.ts
@@ -327,6 +327,21 @@ export class FineTuningBroker extends ReadOnlyFineTuningBroker {
      *
      * For the normal happy path always prefer {@link FineTuningBroker.acknowledgeModel}
      * — it downloads, verifies the model hash, and acks in one step.
+     *
+     * @param providerAddress - The on-chain address of the provider that
+     *   served the task. Must be the same provider passed to
+     *   {@link FineTuningBroker.createTask} for `taskId`.
+     * @param taskId - The task identifier returned by
+     *   {@link FineTuningBroker.createTask}, in 0x-prefixed hex form.
+     * @param gasPrice - Optional gas price (wei) for the
+     *   `acknowledgeDeliverable` transaction. When omitted the broker uses
+     *   the network-suggested gas price.
+     * @returns A promise that resolves once the on-chain transaction has
+     *   been mined and the deliverable is acknowledged.
+     * @throws An `Error` formatted by `throwFormattedError` if the on-chain
+     *   call reverts (e.g. the deliverable is already acknowledged, the
+     *   task does not belong to the caller, or the provider has no pending
+     *   deliverable for the user).
      */
     public acknowledgeDeliverable = async (
         providerAddress: string,

--- a/src.ts/sdk/fine-tuning/broker/model.ts
+++ b/src.ts/sdk/fine-tuning/broker/model.ts
@@ -48,7 +48,9 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
      */
     protected async getStorageConfig(): Promise<StorageConfig> {
         try {
-            const chainId = await this.contract.signer.provider?.getNetwork().then(n => n.chainId)
+            const chainId = await this.contract.signer.provider
+                ?.getNetwork()
+                .then((n) => n.chainId)
             const networkType = chainId ? getNetworkType(chainId) : 'unknown'
 
             if (networkType === 'mainnet') {
@@ -97,9 +99,7 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
                 taskId
             )
 
-            logger.debug(
-                `deliverable: ${deliverable.modelRootHash}`
-            )
+            logger.debug(`deliverable: ${deliverable.modelRootHash}`)
 
             if (!deliverable) {
                 throw new Error('No deliverable found')
@@ -137,16 +137,18 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
             } else if (downloadMethod === '0g-storage') {
                 // Download from 0G Storage with built-in hash verification
                 const storageConfig = await this.getStorageConfig()
-                await download(storageDownloadPath, deliverable.modelRootHash, storageConfig)
+                await download(
+                    storageDownloadPath,
+                    deliverable.modelRootHash,
+                    storageConfig
+                )
                 logger.info(
                     `Successfully downloaded model from 0G Storage to ${storageDownloadPath}`
                 )
             } else {
                 // Auto mode: try 0G Storage first, fallback to TEE
                 try {
-                    logger.info(
-                        'Downloading model from 0G Storage...'
-                    )
+                    logger.info('Downloading model from 0G Storage...')
                     const storageConfig = await this.getStorageConfig()
                     await download(
                         storageDownloadPath,
@@ -189,7 +191,85 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
     }
 
     /**
-     * Download model from 0G Storage (original method, for encrypted full model)
+     * Acknowledge a delivered task on-chain *without* downloading or
+     * verifying the model artifact.
+     *
+     * This is the escape hatch for the failure mode reported in the May
+     * 2026 hackathon bug report (Bug #4): a user retrieved a model via
+     * the legacy two-step `downloadModelFrom0GStorage` + `decryptModel`
+     * flow and forgot to call `acknowledgeModel`. Days later the artifact
+     * was garbage-collected from both 0G Storage and the TEE buffer, at
+     * which point `acknowledgeModel` could no longer succeed (it requires
+     * a successful download), and the user's deliverable queue was
+     * permanently locked — every subsequent `addDeliverable` reverted with
+     * "previous deliverable not acknowledged".
+     *
+     * Calling this method directly with the stuck task id releases the
+     * queue without requiring any artifact retrieval.
+     *
+     * Prefer `acknowledgeModel(...)` for the normal happy path; that
+     * function downloads, verifies the artifact hash, and then acks. Use
+     * `acknowledgeDeliverable` only when:
+     *   - the artifact is gone or you have already retrieved it offline, AND
+     *   - you accept that no on-chain hash verification is performed.
+     *
+     * @param providerAddress - Address of the provider who delivered the task
+     * @param taskId - The task id whose deliverable is to be acknowledged
+     * @param gasPrice - Optional gas price override for the on-chain transaction
+     */
+    async acknowledgeDeliverable(
+        providerAddress: string,
+        taskId: string,
+        gasPrice?: number
+    ): Promise<void> {
+        try {
+            const deliverable = await this.contract.getDeliverable(
+                providerAddress,
+                taskId
+            )
+            if (!deliverable) {
+                throw new Error(`No deliverable found for task ${taskId}`)
+            }
+            if (deliverable.acknowledged) {
+                logger.info(
+                    `Deliverable for task ${taskId} is already acknowledged on-chain — nothing to do.`
+                )
+                return
+            }
+
+            await this.contract.acknowledgeDeliverable(
+                providerAddress,
+                taskId,
+                gasPrice
+            )
+            logger.info(
+                `Acknowledged deliverable for task ${taskId} (provider ${providerAddress}). ` +
+                    'Note: no model hash was verified by this call. ' +
+                    'If you have not yet retrieved the artifact, call acknowledgeModel(...) instead.'
+            )
+        } catch (error) {
+            throwFormattedError(error)
+        }
+    }
+
+    /**
+     * Download the encrypted model file from 0G Storage.
+     *
+     * @deprecated For the normal retrieval flow prefer
+     * {@link ModelProcessor.acknowledgeModel} which downloads, verifies the
+     * on-chain model hash, and acknowledges the deliverable in one call.
+     *
+     * Calling this method on its own (without a subsequent
+     * {@link ModelProcessor.acknowledgeDeliverable} or
+     * {@link ModelProcessor.acknowledgeModel}) leaves the deliverable in an
+     * "unacknowledged" state on-chain. The provider contract then rejects
+     * any future `addDeliverable` for the same `(user, provider)` pair
+     * with "previous deliverable not acknowledged", permanently locking
+     * the user's queue. This is the May 2026 bug report's Bug #4 trigger.
+     *
+     * Use this method only as part of an advanced retrieval pipeline where
+     * you control acknowledgement separately, and remember to call
+     * `acknowledgeDeliverable(provider, taskId)` afterwards.
      */
     async downloadModelFrom0GStorage(
         providerAddress: string,
@@ -211,17 +291,18 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
             try {
                 const stats = await fs.stat(dataPath)
                 if (stats.isDirectory()) {
-                    downloadPath = path.join(
-                        dataPath,
-                        `model_${taskId}.bin`
-                    )
+                    downloadPath = path.join(dataPath, `model_${taskId}.bin`)
                 }
             } catch {
                 // Path doesn't exist yet, use as-is
             }
 
             const storageConfig = await this.getStorageConfig()
-            await download(downloadPath, deliverable.modelRootHash, storageConfig)
+            await download(
+                downloadPath,
+                deliverable.modelRootHash,
+                storageConfig
+            )
             logger.info(
                 `Successfully downloaded model from 0G Storage to ${downloadPath}`
             )
@@ -301,9 +382,7 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
                         `Hash mismatch for task ${taskId}: expected ${expectedHash}, got ${computedHash}`
                     )
                 } else {
-                    logger.info(
-                        `Hash verification passed for task ${taskId}`
-                    )
+                    logger.info(`Hash verification passed for task ${taskId}`)
                 }
             } else {
                 logger.info(
@@ -315,7 +394,7 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
         }
     }
 
-        /**
+    /**
      * Decrypt a fine-tuned model after acknowledgement.
      * Uses the user's private key to decrypt the model encryption key,
      * then decrypts the model file.
@@ -336,10 +415,19 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
      * );
      * ```
      *
+     * @deprecated For the normal retrieval flow prefer
+     * {@link ModelProcessor.acknowledgeModel} which downloads, verifies, and
+     * acknowledges in one call. `decryptModel` is the second half of the
+     * legacy two-step pattern (`downloadModelFrom0GStorage` + `decryptModel`)
+     * — neither half acknowledges the deliverable on-chain. Forgetting the
+     * acknowledgement is what triggered Bug #4 in the May 2026 hackathon
+     * bug report, where a user's task queue became permanently locked.
+     *
      * @remarks
      * The model can only be decrypted after:
      * 1. The provider has delivered the encrypted model
-     * 2. The user has acknowledged the model (called acknowledgeModel)
+     * 2. The user has acknowledged the model (called acknowledgeModel
+     *    OR acknowledgeDeliverable)
      * 3. The provider has shared the encrypted decryption key
      */
     async decryptModel(
@@ -361,7 +449,15 @@ export class ModelProcessor extends ReadOnlyModelProcessor {
             }
 
             if (!deliverable.acknowledged) {
-                throw new Error('Deliverable not acknowledged yet')
+                throw new Error(
+                    `Deliverable for task ${taskId} is not acknowledged yet. ` +
+                        'Call broker.fineTuning.acknowledgeModel(provider, taskId, dataPath) ' +
+                        '(preferred — downloads, verifies, and acks) ' +
+                        'or broker.fineTuning.acknowledgeDeliverable(provider, taskId) ' +
+                        '(if the artifact is no longer retrievable). ' +
+                        'Without acknowledgement the user queue stays locked and any future ' +
+                        'fine-tune task will fail with "previous deliverable not acknowledged".'
+                )
             }
 
             if (!deliverable.encryptedSecret) {

--- a/src.ts/sdk/fine-tuning/token/token.ts
+++ b/src.ts/sdk/fine-tuning/token/token.ts
@@ -55,7 +55,8 @@ export async function calculateTokenSizeViaExe(
     await initNodeModules()
     const { download } = await safeDynamicImport()
 
-    const executorDir = path.join(__dirname, '..', '..', '..', '..', 'binary')
+    const binaryPathModule = await import('../zg-storage/binary-path')
+    const executorDir = binaryPathModule.getBinaryDir()
     const binaryFile = path.join(executorDir, 'token_counter')
 
     let needDownload = false
@@ -120,7 +121,8 @@ export async function calculateTokenSizeViaPython(
             }
         }
     }
-    const projectRoot = path.resolve(__dirname, '../../../../')
+    const binaryPathModule = await import('../zg-storage/binary-path')
+    const projectRoot = binaryPathModule.getPackageRoot()
     return await calculateTokenSize(
         tokenizerRootHash,
         datasetPath,

--- a/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
+++ b/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
@@ -30,9 +30,22 @@
  *     Node 22+ refuses to load any ESM file containing `require()` calls
  *     mixed with top-level `await`, which would break SDK import for every
  *     ESM consumer of the package.
- *   - `__dirname` is read via `globalThis` so the static reference resolves
- *     in both CJS (where Node injects `__dirname` per module) and ESM
- *     (where `globalThis.__dirname` is `undefined` and we fall back).
+ *   - `__dirname` is module-scoped in CJS (Node injects it into each
+ *     module wrapper) and is provided in the ESM bundle via a banner
+ *     shim defined in `rollup.config.mjs` that derives it from
+ *     `import.meta.url` once at the top of `lib.esm/index.mjs`. This
+ *     guarantees the anchor lives inside the installed package
+ *     (`<pkg>/lib.esm/` for ESM, `<pkg>/lib.commonjs/.../zg-storage/`
+ *     for CJS) so the upward `findAncestorContaining` walk locates
+ *     `<pkg>/binary/` reliably regardless of the consumer's `cwd`.
+ *
+ *     The earlier `process.cwd()` fallback was incorrect for the ESM
+ *     case: from a downstream ESM consumer, `cwd` is the consumer's
+ *     project root and the SDK's `binary/` directory lives **below**
+ *     it inside `node_modules/`, so an upward walk would never find it.
+ *     The fallback is retained only as a defensive guard for unusual
+ *     bundlers that might strip the banner; in the standard rollup
+ *     output `__dirname` is always defined and the fallback is unused.
  */
 
 import * as fs from 'fs'

--- a/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
+++ b/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
@@ -7,7 +7,8 @@
  *
  * Why this exists:
  *
- * The legacy implementation hard-coded `path.join(__dirname, '..', '..', '..', '..', 'binary', '0g-storage-client')`,
+ * The legacy implementation hard-coded
+ * `path.join(__dirname, '..', '..', '..', '..', 'binary', '0g-storage-client')`,
  * which assumed a fixed depth of 4 between the runtime file and the package
  * root. That assumption was wrong by one level for the CommonJS build
  * (3 levels up from `lib.commonjs/fine-tuning/zg-storage/zg-storage.js`)
@@ -15,23 +16,48 @@
  * silently fell back to the slower TEE HTTP path or, worse, threw `ENOENT`
  * — see "0G-Compute-SDK Fine-tune Pipeline Bug Report" (May 2026, Bug #1).
  *
- * The fix walks up the directory tree from `__dirname` and stops at the
+ * The fix walks up the directory tree from a known anchor and stops at the
  * first ancestor that contains a `binary/` sub-directory. This works for
  * any reasonable bundle layout, is robust against future refactors, and
  * produces a clear actionable error if the binary is missing entirely
  * (Bug #2 — multi-arch support).
+ *
+ * Note on the dual ESM/CJS build:
+ *
+ *   - We use standard `import` statements for `fs`/`path` so tsc emits
+ *     CJS `require()` for `lib.commonjs/` and rollup keeps them as ES
+ *     imports for `lib.esm/`. We do NOT use top-level `require()`:
+ *     Node 22+ refuses to load any ESM file containing `require()` calls
+ *     mixed with top-level `await`, which would break SDK import for every
+ *     ESM consumer of the package.
+ *   - `__dirname` is read via `globalThis` so the static reference resolves
+ *     in both CJS (where Node injects `__dirname` per module) and ESM
+ *     (where `globalThis.__dirname` is `undefined` and we fall back).
  */
 
-import type * as fsTypes from 'fs'
-import type * as pathTypes from 'path'
+import * as fs from 'fs'
+import * as path from 'path'
 
-// We intentionally use require() instead of `import` here so this module
-// stays compatible with both ESM and CommonJS bundle outputs without
-// triggering rollup ESM/CJS interop quirks.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const fs = require('fs') as typeof fsTypes
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path') as typeof pathTypes
+/**
+ * Best-effort directory anchor for the running module.
+ *
+ * - CommonJS: returns the per-module `__dirname` Node injects into each
+ *   module's lexical scope. Note that `__dirname` is **not** a global on
+ *   `globalThis` — it is supplied by Node's module wrapper. This is why
+ *   we read it lexically (the `typeof __dirname !== 'undefined'` check
+ *   is the standard JS idiom for reading a possibly-undeclared symbol
+ *   without raising `ReferenceError`).
+ * - ESM bundle: `__dirname` is undeclared, so we fall back to
+ *   `process.cwd()`. The downstream `findAncestorContaining` walk can
+ *   still recover the correct `binary/` directory when the consumer is
+ *   running from inside the installed package tree.
+ */
+function getAnchorDir(): string {
+    if (typeof __dirname !== 'undefined') {
+        return __dirname
+    }
+    return process.cwd()
+}
 
 /**
  * Find the first ancestor of `start` (inclusive) that contains a directory
@@ -40,7 +66,6 @@ const path = require('path') as typeof pathTypes
  */
 function findAncestorContaining(start: string, marker: string): string | null {
     let dir = start
-    // Cap the climb so a misconfigured build can never spin forever.
     for (let i = 0; i < 32; i++) {
         const candidate = path.join(dir, marker)
         try {
@@ -81,10 +106,9 @@ export function getPackageRoot(): string {
         }
         return cachedRoot
     }
-    const found = findAncestorContaining(__dirname, 'binary')
+    const found = findAncestorContaining(getAnchorDir(), 'binary')
     cachedRoot = found
     if (cachedRoot === null) {
-        // Reuse the same error path so the cached behaviour is consistent.
         return getPackageRoot()
     }
     return cachedRoot
@@ -100,7 +124,7 @@ export function getBinaryDir(): string {
 /**
  * Returns the absolute path of a specific binary inside `binary/`.
  *
- * Validates that the file exists and is executable. If not, raises an
+ * Validates that the file exists and is a regular file. If not, raises an
  * actionable error pointing the user at the multi-arch caveat: the SDK
  * currently ships a single Linux-x64 ELF binary; users on macOS arm64,
  * Linux arm64, or Windows must rebuild from source until per-platform
@@ -109,7 +133,7 @@ export function getBinaryDir(): string {
  */
 export function getBundledBinary(name: string): string {
     const candidate = path.join(getBinaryDir(), name)
-    let stats: fsTypes.Stats
+    let stats: fs.Stats
     try {
         stats = fs.statSync(candidate)
     } catch (err) {

--- a/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
+++ b/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
@@ -1,0 +1,131 @@
+/**
+ * Resolve the absolute path of bundled binaries inside this package
+ * (`binary/0g-storage-client`, `binary/token_counter`, etc.) regardless of
+ * whether the SDK is running from the CommonJS build (`lib.commonjs/...`,
+ * deeply nested) or the ESM bundle (`lib.esm/index.mjs`, single file at the
+ * package root).
+ *
+ * Why this exists:
+ *
+ * The legacy implementation hard-coded `path.join(__dirname, '..', '..', '..', '..', 'binary', '0g-storage-client')`,
+ * which assumed a fixed depth of 4 between the runtime file and the package
+ * root. That assumption was wrong by one level for the CommonJS build
+ * (3 levels up from `lib.commonjs/fine-tuning/zg-storage/zg-storage.js`)
+ * and would have been wrong by three levels for the ESM bundle. The SDK
+ * silently fell back to the slower TEE HTTP path or, worse, threw `ENOENT`
+ * — see "0G-Compute-SDK Fine-tune Pipeline Bug Report" (May 2026, Bug #1).
+ *
+ * The fix walks up the directory tree from `__dirname` and stops at the
+ * first ancestor that contains a `binary/` sub-directory. This works for
+ * any reasonable bundle layout, is robust against future refactors, and
+ * produces a clear actionable error if the binary is missing entirely
+ * (Bug #2 — multi-arch support).
+ */
+
+import type * as fsTypes from 'fs'
+import type * as pathTypes from 'path'
+
+// We intentionally use require() instead of `import` here so this module
+// stays compatible with both ESM and CommonJS bundle outputs without
+// triggering rollup ESM/CJS interop quirks.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require('fs') as typeof fsTypes
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('path') as typeof pathTypes
+
+/**
+ * Find the first ancestor of `start` (inclusive) that contains a directory
+ * named `marker`. Returns the absolute path of the ancestor, or `null` if
+ * no such ancestor exists before reaching the filesystem root.
+ */
+function findAncestorContaining(start: string, marker: string): string | null {
+    let dir = start
+    // Cap the climb so a misconfigured build can never spin forever.
+    for (let i = 0; i < 32; i++) {
+        const candidate = path.join(dir, marker)
+        try {
+            if (fs.statSync(candidate).isDirectory()) {
+                return dir
+            }
+        } catch {
+            // marker not present at this level — keep climbing
+        }
+        const parent = path.dirname(dir)
+        if (parent === dir) {
+            return null
+        }
+        dir = parent
+    }
+    return null
+}
+
+let cachedRoot: string | null | undefined
+
+/**
+ * Returns the absolute path of the package root that contains the bundled
+ * `binary/` directory. Cached after first lookup.
+ *
+ * Throws if no such directory can be found (means the package was
+ * installed without the binary, e.g. someone copied only `lib.commonjs/`
+ * out of `node_modules`).
+ */
+export function getPackageRoot(): string {
+    if (cachedRoot !== undefined) {
+        if (cachedRoot === null) {
+            throw new Error(
+                'Could not locate the bundled `binary/` directory relative to the SDK at runtime. ' +
+                    'This typically means the @0gfoundation/0g-compute-ts-sdk package was installed ' +
+                    'without its bundled assets (for example, only `lib.commonjs/` was copied). ' +
+                    'Reinstall via `npm i` / `pnpm i` so the full package layout including `binary/` is present.'
+            )
+        }
+        return cachedRoot
+    }
+    const found = findAncestorContaining(__dirname, 'binary')
+    cachedRoot = found
+    if (cachedRoot === null) {
+        // Reuse the same error path so the cached behaviour is consistent.
+        return getPackageRoot()
+    }
+    return cachedRoot
+}
+
+/**
+ * Returns the absolute path of the bundled `binary/` directory.
+ */
+export function getBinaryDir(): string {
+    return path.join(getPackageRoot(), 'binary')
+}
+
+/**
+ * Returns the absolute path of a specific binary inside `binary/`.
+ *
+ * Validates that the file exists and is executable. If not, raises an
+ * actionable error pointing the user at the multi-arch caveat: the SDK
+ * currently ships a single Linux-x64 ELF binary; users on macOS arm64,
+ * Linux arm64, or Windows must rebuild from source until per-platform
+ * binaries are added (Bug #2). The error spells out the workaround so a
+ * developer is not left staring at a generic `ENOENT` or `ENOEXEC`.
+ */
+export function getBundledBinary(name: string): string {
+    const candidate = path.join(getBinaryDir(), name)
+    let stats: fsTypes.Stats
+    try {
+        stats = fs.statSync(candidate)
+    } catch (err) {
+        const platformHint = `${process.platform}/${process.arch}`
+        throw new Error(
+            `Bundled binary "${name}" was not found at ${candidate} (running on ${platformHint}). ` +
+                'The SDK currently ships only the linux/x64 build of 0g-storage-client. ' +
+                'On other platforms, build it from source at ' +
+                'https://github.com/0gfoundation/0g-storage-client and copy the resulting binary into the package `binary/` directory. ' +
+                `Underlying error: ${(err as Error).message}`
+        )
+    }
+    if (!stats.isFile()) {
+        throw new Error(
+            `Bundled binary "${name}" at ${candidate} is not a regular file.`
+        )
+    }
+    return candidate
+}

--- a/src.ts/sdk/fine-tuning/zg-storage/zg-storage.ts
+++ b/src.ts/sdk/fine-tuning/zg-storage/zg-storage.ts
@@ -1,11 +1,8 @@
-import {
-    INDEXER_URL_TESTNET_TURBO,
-    ZG_RPC_ENDPOINT_TESTNET,
-} from '../const'
+import { INDEXER_URL_TESTNET_TURBO, ZG_RPC_ENDPOINT_TESTNET } from '../const'
 import { spawn } from 'child_process'
-import path from 'path'
 import * as fs from 'fs/promises'
 import { logger } from '../../common/logger'
+import { getBundledBinary } from './binary-path'
 
 export interface StorageConfig {
     rpcUrl?: string
@@ -27,15 +24,7 @@ export async function upload(
         const indexerUrl = config?.indexerUrl || INDEXER_URL_TESTNET_TURBO
 
         return new Promise((resolve, reject) => {
-            const command = path.join(
-                __dirname,
-                '..',
-                '..',
-                '..',
-                '..',
-                'binary',
-                '0g-storage-client'
-            )
+            const command = getBundledBinary('0g-storage-client')
             const args = [
                 'upload',
                 '--url',
@@ -65,9 +54,7 @@ export async function upload(
                 const output = data.toString()
                 logger.debug(output)
                 // Capture root hash from output: "file uploaded, root = 0x..."
-                const match = output.match(
-                    /root\s*=\s*(0x[0-9a-fA-F]+)/
-                )
+                const match = output.match(/root\s*=\s*(0x[0-9a-fA-F]+)/)
                 if (match) {
                     rootHash = match[1]
                 }
@@ -77,9 +64,7 @@ export async function upload(
                 const output = data.toString()
                 logger.warn(output)
                 // Also check stderr since some log output goes to stderr
-                const match = output.match(
-                    /root\s*=\s*(0x[0-9a-fA-F]+)/
-                )
+                const match = output.match(/root\s*=\s*(0x[0-9a-fA-F]+)/)
                 if (match) {
                     rootHash = match[1]
                 }
@@ -119,15 +104,7 @@ export async function download(
     const indexerUrl = config?.indexerUrl || INDEXER_URL_TESTNET_TURBO
 
     return new Promise((resolve, reject) => {
-        const command = path.join(
-            __dirname,
-            '..',
-            '..',
-            '..',
-            '..',
-            'binary',
-            '0g-storage-client'
-        )
+        const command = getBundledBinary('0g-storage-client')
 
         const args = [
             'download',


### PR DESCRIPTION
## Context

The May 2026 0G APAC Hackathon team filed a 5-issue bug report on the
fine-tune SDK + provider pipeline (`0G-Compute-SDK Fine-tune Pipeline
Bug Report.docx`). This PR ships the four SDK-side fixes; **Bug #3**
(inference-broker `pushAdapterKey` HTTP 500) is the companion broker
PR [`0g-serving-broker#479`](https://github.com/0gfoundation/0g-serving-broker/pull/479).

| Bug | Severity | Status in this PR |
|----|----------|------------------|
| #1 — `__dirname` off-by-one binary path traversal | High | Fixed |
| #2 — bundled `0g-storage-client` is linux/x64-only with no friendly hint | Medium | Friendlier error + scaffolding for multi-arch |
| #3 — `pushAdapterKey` HTTP 500 + retry loop | **Critical** | Fixed in companion broker PR #479 |
| #4 — no way to acknowledge a deliverable without artifact retrieval → permanent queue lock | High | Fixed |
| #5 — `downloadModelFrom0GStorage` + `decryptModel` had no warning, encouraged the failure mode that triggers Bug #4 | Medium | Fixed |

## Changes

### Bug #1 + #2 — robust binary path resolution
New helper `src.ts/sdk/fine-tuning/zg-storage/binary-path.ts` walks up
the directory tree from `__dirname` looking for the first ancestor
containing a `binary/` sub-directory and exposes:

- `getPackageRoot()` — cached package-root lookup
- `getBinaryDir()` — absolute path of bundled `binary/`
- `getBundledBinary(name)` — resolves + `statSync`-checks a single
  binary, throws an actionable error mentioning the running
  `process.platform`/`process.arch` and pointing the user at
  https://github.com/0gfoundation/0g-storage-client to rebuild if the
  bundled blob is missing or platform-incompatible.

`zg-storage.ts` and `token/token.ts` now use these helpers instead of
the hard-coded `path.join(__dirname, '..','..','..','..','binary',...)`,
which had been wrong by one level for the CommonJS build and would have
been wrong by three levels for the rolled-up ESM bundle. Verified at
runtime that `lib.commonjs/`, `lib.esm/` and `cli.commonjs/` all
resolve to `<package>/binary/0g-storage-client`.

### Bug #4 — escape hatch for locked deliverable queues
`ModelProcessor.acknowledgeDeliverable(provider, taskId, gasPrice?)` is
a new public method that calls the on-chain `acknowledgeDeliverable`
**without** requiring a model download. It first checks
`getDeliverable()` and short-circuits if already acknowledged. This is
the only recovery path when the artifact has been GC'd from both 0G
Storage and TEE buffers but the deliverable remains unacknowledged —
exactly the failure that triggered Bug #4.

- Re-exported on `FineTuningBroker.acknowledgeDeliverable()`
- Exposed in the CLI as
  `0g-compute-cli fine-tuning acknowledge-deliverable --provider <addr> --task-id <id>`

### Bug #5 — deprecate the misleading two-step retrieval API
`downloadModelFrom0GStorage` and `decryptModel` now carry `@deprecated`
JSDoc on both the SDK class methods (`model.ts`) and the broker
re-exports (`broker.ts`). The notes spell out the queue-locking failure
mode and direct users to `acknowledgeModel` (happy path) or
`acknowledgeDeliverable` (escape hatch). `decryptModel` also raises a
more actionable error when invoked on an unacknowledged deliverable.

`Interface.md` updated with a Note pointing at the recommended retrieval
flow and the escape hatch.

### Misc
- CLI `acknowledge-model` gains an optional `--inference-provider`
  option so cross-provider `--deploy` works without piggy-backing on
  `--provider`.
- Prettier reformatted touched files.

## Verification

- [x] `npx tsc -p tsconfig.commonjs.json --noEmit` — clean
- [x] `npx tsc -p tsconfig.cli.json --noEmit` — clean
- [x] `npx eslint <changed files>` — 0 errors (only pre-existing warnings remain)
- [x] `npm run build` — `lib.commonjs`, `lib.esm`, `cli.commonjs` produced successfully
- [x] Runtime smoke test of `getBundledBinary('0g-storage-client')` in both `lib.commonjs` and `cli.commonjs` returned the correct absolute path.

## Test plan for reviewer

- [ ] Hackathon team reproduces with this branch (or a published prerelease) and confirms the locked-queue scenario can now be cleared via `acknowledge-deliverable`.
- [ ] Sanity-check `acknowledge-model` happy path still works end-to-end (no regression in binary path resolution).
- [ ] Verify `0g-compute-cli fine-tuning acknowledge-deliverable --help` text reads correctly.