### PR TITLE
chore: release v0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0gfoundation/0g-compute-ts-sdk",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {


### PR DESCRIPTION
## Summary

Patch release rolling up the May 2026 hackathon fine-tune pipeline fixes from #208 (Bug #1, #2, #4, #5).

| Bug | Severity | Fix |
|-----|----------|-----|
| #1 — `__dirname` off-by-one binary path traversal | High | New `getBundledBinary` helper + ESM Rollup banner injecting `__dirname` from `import.meta.url` |
| #2 — bundled `0g-storage-client` is linux/x64-only | Medium | Actionable platform/arch error (multi-arch packaging tracked separately) |
| #4 — locked deliverable queue with no recovery path | High | New `FineTuningBroker.acknowledgeDeliverable` + CLI `acknowledge-deliverable` subcommand |
| #5 — misleading two-step retrieval API | Medium | `downloadModelFrom0GStorage` / `decryptModel` marked `@deprecated`; `decryptModel` throws an actionable error on unacknowledged deliverables |

Bug #3 (inference-broker `pushAdapterKey` HTTP 500) is in the companion broker repo and is independent of this SDK release.

## Test plan

- [x] `npm run build` — clean (CommonJS, ESM, types, CLI all emitted)
- [x] ESM banner verified present in `lib.esm/index.mjs` and every emitted chunk
- [ ] Reviewer: smoke-test from a downstream ESM consumer (`import { createFineTuningBroker } from '@0gfoundation/0g-compute-ts-sdk'` + invoke a path that calls `getBundledBinary`)
- [ ] After merge: tag `v0.8.1`, create GitHub release, `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)