### PR TITLE
docs(fine-tuning): document stuck deliverable queue recovery recipe

### DIFF
--- a/Interface.md
+++ b/Interface.md
@@ -47,8 +47,65 @@
 > the user's task queue ("previous deliverable not acknowledged" revert on
 > the next `addDeliverable`). If the artifact is no longer retrievable, use
 > the escape hatch `acknowledgeDeliverable(provider, taskId)` (or the CLI
-> command `0g-compute-cli fine-tuning acknowledge-deliverable`) to release
-> the queue without artifact download.
+> command `0g-compute-cli fine-tuning acknowledge-deliverable`) — see the
+> recovery recipe below.
+
+### Recovering a stuck deliverable queue
+
+The on-chain fine-tuning account holds at most one **un-acknowledged**
+deliverable per `(user, provider)` pair. Until that flag is set,
+`addDeliverable` for the same pair reverts with `previous deliverable not
+acknowledged`, and any new `createTask` to the same provider fails. Common
+ways to land in this state:
+
+1. The user retrieved the model out-of-band (legacy
+   `downloadModelFrom0GStorage` + `decryptModel`) and never called
+   `acknowledgeModel`.
+2. `acknowledgeModel` started the download but it never finished — for
+   example on macOS where `auto` falls back from the linux/x64 0G-Storage
+   binary to the TEE HTTP path, and the TEE stream aborts a few minutes in
+   for large models (`stream has been aborted`).
+3. The artifact has aged out of both 0G Storage and the provider's TEE
+   buffer, so no retry of `acknowledgeModel` can ever succeed.
+
+In all three cases the fix is to acknowledge on-chain *without* downloading
+the artifact. Since `@0gfoundation/0g-compute-ts-sdk@0.8.1` this is a
+first-class public API — you do **not** need to call the contract directly:
+
+```ts
+// SDK (preferred — adds error decoration and gas-price handling)
+await broker.acknowledgeDeliverable(providerAddress, taskId)
+```
+
+```bash
+# CLI (same effect)
+0g-compute-cli fine-tuning acknowledge-deliverable \
+    --provider <provider-address> \
+    --task-id  <task-id>
+```
+
+This is a **sanctioned, permanent escape hatch**, not a temporary
+workaround — it has the same on-chain effect as the second half of
+`acknowledgeModel`, and we will not change its shape. Once the call is
+mined the provider auto-settles within ~10 minutes and the wallet can
+queue another fine-tune to the same provider.
+
+For the normal happy path always prefer `acknowledgeModel` — it
+downloads the encrypted artifact, verifies its hash against the
+`Deliverable.modelRootHash` recorded on-chain, and acknowledges in one
+step. Use `acknowledgeDeliverable` only when the download cannot
+complete or the artifact is no longer needed.
+
+> **macOS users — bundled binary caveat.** The 0G-Storage binary shipped
+> in `node_modules/@0gfoundation/0g-compute-ts-sdk/binary/` is a
+> linux/x64 ELF; on darwin or linux/arm64 the SDK throws a friendly
+> "platform/arch mismatch" error and `acknowledgeModel` with
+> `downloadMethod: 'auto'` falls back to the TEE HTTP path. To make the
+> 0G-Storage path work on macOS, build a darwin binary from
+> [`0gfoundation/0g-storage-client`](https://github.com/0gfoundation/0g-storage-client)
+> and drop it into the same `binary/` directory. Multi-arch shipping is
+> tracked separately and is **not** required for the recovery recipe
+> above — `acknowledgeDeliverable` does not invoke the binary at all.
 
 ### Code Structure
 


### PR DESCRIPTION
## Summary

Expand the existing `acknowledgeModel` note in `Interface.md` into a self-contained **"Recovering a stuck deliverable queue"** section.

Follow-up to #208 — pure docs, no code changes.

## Why

A hackathon team using `@0gfoundation/0g-compute-ts-sdk@0.8.1` filed Bug #7 in the May 2026 bug report:

> `downloadMethod: 'auto'` falls from 0G Storage to TEE on macOS (Bug #2 still). TEE HTTP stream aborts ~5–6 min in (`stream has been aborted`). Without download, ack never fires → triggers Bug #6.
>
> Question: is calling `contract.acknowledgeDeliverable(provider, taskId)` direct (skipping artifact download) a sanctioned pattern?

The answer is **yes** — that's exactly the public escape hatch shipped in #208 (`broker.acknowledgeDeliverable` + the `acknowledge-deliverable` CLI command). But the existing note in `Interface.md` was a single inline blockquote that was easy to miss and didn't spell out:

- the three concrete ways users land in a stuck-queue state (legacy two-step retrieval, partially-completed `acknowledgeModel`, expired artifact),
- the **public SDK / CLI surfaces** to use instead of a raw contract call,
- the long-term semantics (sanctioned permanent escape hatch, no shape change planned),
- the **macOS bundled-binary caveat** that commonly triggers the stuck-queue state in the first place, and the fact that the recovery recipe doesn't depend on the binary at all.

This PR consolidates all of the above into one searchable section so the next team running into Bug #4 / Bug #7 can find it directly.

## Changes

- `Interface.md`
  - Trim the existing inline note from "use the escape hatch … to release the queue without artifact download." to "… — see the recovery recipe below.", pointing at the new section.
  - Add `### Recovering a stuck deliverable queue` containing:
    - When the state is reachable (3 enumerated triggers).
    - SDK + CLI snippets for `acknowledgeDeliverable` / `acknowledge-deliverable`.
    - Long-term semantics: sanctioned permanent escape hatch, same on-chain effect as the second half of `acknowledgeModel`, provider auto-settles ~10 min later.
    - Reminder that `acknowledgeModel` is still the preferred happy-path entry.
    - macOS / linux-arm64 bundled-binary caveat with a pointer to `0gfoundation/0g-storage-client` for rebuilding, and an explicit note that the recovery recipe never invokes the binary.

## Test plan

- [x] `git diff Interface.md` reviewed; only additions/edits to the targeted section.
- [x] No code changes → no build / unit-test impact.
- [x] Manually verified the documented surfaces exist and behave as described in `@0gfoundation/0g-compute-ts-sdk@0.8.1`:
  - `typeof broker.acknowledgeDeliverable === 'function'` ✅
  - `0g-compute-cli fine-tuning acknowledge-deliverable --help` shows the escape-hatch description ✅