### PR TITLE
Add USD pricing display to inference CLI output

### DIFF
--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -327,6 +327,22 @@ export default function inference(program: Command) {
                             table.push(['Cache Hit Price Per Token (0G)', cacheHitPrice])
                         }
                     }
+
+                    const pricingUSD = modelInfo?.pricingUSD
+                    if (pricingUSD) {
+                        if (!isImageService && pricingUSD.prompt) {
+                            table.push(['Input Price Per Token (USD)', pricingUSD.prompt])
+                        }
+                        if (pricingUSD.image) {
+                            table.push(['Price Per Image (USD)', pricingUSD.image])
+                        } else if (pricingUSD.completion) {
+                            const usdLabel = isImageService
+                                ? 'Price Per Image (USD)'
+                                : 'Output Price Per Token (USD)'
+                            table.push([usdLabel, pricingUSD.completion])
+                        }
+                    }
+
                     table.push([
                         'Verifiability',
                         service.verifiability || 'N/A',

--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -328,7 +328,7 @@ export default function inference(program: Command) {
                         }
                     }
 
-                    const pricingUSD = modelInfo?.pricingUSD
+                    const pricingUSD = modelInfo?.pricing_usd
                     if (pricingUSD) {
                         if (!isImageService && pricingUSD.prompt) {
                             table.push(['Input Price Per Token (USD)', pricingUSD.prompt])

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -249,21 +249,6 @@ export function parseCacheTokenBillingFromModelInfo(
 }
 
 /**
- * Price feed state returned by the status API at /models.
- * Reports the conversion rate from native token to USD plus freshness metadata.
- */
-export interface PriceFeedState {
-    /** Conversion rate: USD per 1 OG (decimal string) */
-    rate_usd_per_og?: string
-    /** ISO 8601 timestamp of the last successful update */
-    updated_at?: string
-    /** ISO 8601 timestamp of the next scheduled update */
-    next_update_time?: string
-    /** Whether the rate is considered stale (e.g. update failed or expired) */
-    is_stale?: boolean
-}
-
-/**
  * Service information with optional health metrics and provider model info
  */
 export interface ServiceWithDetail {
@@ -447,27 +432,6 @@ export class ReadOnlyModelProcessor {
             return servicesWithDetail
         } catch (error) {
             throwFormattedError(error)
-        }
-    }
-
-    /**
-     * Fetch the OG/USD price feed state from the status API's /models endpoint.
-     * Returns undefined if the endpoint is unreachable or doesn't include price_feed.
-     */
-    async getPriceFeed(): Promise<PriceFeedState | undefined> {
-        try {
-            const chainId = await this.contract.getChainId()
-            const statusApiEndpoint = this.getStatusApiEndpoint(chainId)
-            const r = await axios.get(`${statusApiEndpoint}/models`, {
-                timeout: 10000,
-            })
-            const feed = r.data?.price_feed
-            if (feed && typeof feed === 'object') {
-                return feed as PriceFeedState
-            }
-            return undefined
-        } catch {
-            return undefined
         }
     }
 

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -104,6 +104,16 @@ export interface ProviderModelInfo {
         completion?: string
         /** USD price per generated image (image services) */
         image?: string
+        /** Tiered pricing tiers based on input token count */
+        tiered_pricing?: Array<{
+            max_input_tokens: number
+            input_multiplier: number
+            output_multiplier: number
+        }>
+        /** Cache token billing configuration */
+        cache_token_billing?: {
+            divisor: number
+        }
     }
     /** ISO 8601 date string indicating when this model will no longer be served */
     expiration_date?: string

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -97,7 +97,7 @@ export interface ProviderModelInfo {
      * Pricing expressed in USD. Values are decimal strings (e.g. "0.000000175").
      * Returned by the status API alongside `pricing` (which is in native token units).
      */
-    pricingUSD?: {
+    pricing_usd?: {
         /** USD price per prompt token */
         prompt?: string
         /** USD price per completion token */
@@ -236,6 +236,21 @@ export function parseCacheTokenBillingFromModelInfo(
         return { divisor: raw.divisor }
     }
     return undefined
+}
+
+/**
+ * Price feed state returned by the status API at /models.
+ * Reports the conversion rate from native token to USD plus freshness metadata.
+ */
+export interface PriceFeedState {
+    /** Conversion rate: USD per 1 OG (decimal string) */
+    rate_usd_per_og?: string
+    /** ISO 8601 timestamp of the last successful update */
+    updated_at?: string
+    /** ISO 8601 timestamp of the next scheduled update */
+    next_update_time?: string
+    /** Whether the rate is considered stale (e.g. update failed or expired) */
+    is_stale?: boolean
 }
 
 /**
@@ -422,6 +437,27 @@ export class ReadOnlyModelProcessor {
             return servicesWithDetail
         } catch (error) {
             throwFormattedError(error)
+        }
+    }
+
+    /**
+     * Fetch the OG/USD price feed state from the status API's /models endpoint.
+     * Returns undefined if the endpoint is unreachable or doesn't include price_feed.
+     */
+    async getPriceFeed(): Promise<PriceFeedState | undefined> {
+        try {
+            const chainId = await this.contract.getChainId()
+            const statusApiEndpoint = this.getStatusApiEndpoint(chainId)
+            const r = await axios.get(`${statusApiEndpoint}/models`, {
+                timeout: 10000,
+            })
+            const feed = r.data?.price_feed
+            if (feed && typeof feed === 'object') {
+                return feed as PriceFeedState
+            }
+            return undefined
+        } catch {
+            return undefined
         }
     }
 

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -93,6 +93,18 @@ export interface ProviderModelInfo {
             divisor: number
         }
     }
+    /**
+     * Pricing expressed in USD. Values are decimal strings (e.g. "0.000000175").
+     * Returned by the status API alongside `pricing` (which is in native token units).
+     */
+    pricingUSD?: {
+        /** USD price per prompt token */
+        prompt?: string
+        /** USD price per completion token */
+        completion?: string
+        /** USD price per generated image (image services) */
+        image?: string
+    }
     /** ISO 8601 date string indicating when this model will no longer be served */
     expiration_date?: string
     verifiability?: string


### PR DESCRIPTION
## Summary
This PR adds support for displaying USD-denominated pricing information in the inference CLI, complementing the existing native token pricing display.

## Key Changes
- **Type Definition**: Added `pricingUSD` optional field to `ProviderModelInfo` interface with support for:
  - `prompt`: USD price per prompt token
  - `completion`: USD price per completion token
  - `image`: USD price per generated image (for image services)

- **CLI Display**: Enhanced the inference command output to display USD pricing when available:
  - Shows "Input Price Per Token (USD)" for non-image services with prompt pricing
  - Shows "Price Per Image (USD)" for image services with image pricing
  - Falls back to completion pricing with appropriate labeling based on service type

## Implementation Details
- USD prices are represented as decimal strings (e.g., "0.000000175") to maintain precision
- The `pricingUSD` field is returned alongside existing `pricing` field (which uses native token units)
- Display logic intelligently handles both image and token-based services with contextual labels
- Maintains backward compatibility by making the new field optional

https://claude.ai/code/session_01GL8iNpEBiaWT7kL7Kp3uPB