### PR TITLE
chore: release v0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0gfoundation/0g-compute-ts-sdk",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {


### PR DESCRIPTION
## Summary
Patch release rolling up changes since v0.8.1.

- #211 fix(fine-tuning): stop aborting TEE-encrypted model downloads at the 5-minute mark (Bug #7). Long-running downloads from 0G Storage no longer hit a hard timeout that broke acknowledge/decrypt flows on larger models.
- #212 feat(cli): display USD-equivalent pricing alongside token costs in inference CLI output.
- chore(cli): read `--version` from `package.json` instead of a hardcoded literal — the CLI string had silently drifted to `0.8.0` (missed in the v0.8.1 bump). Future releases stay in sync automatically.

## Test plan
- [ ] `pnpm install && pnpm build` succeeds
- [ ] `0g-compute-cli --version` prints `0.8.2`
- [ ] `0g-compute-cli list-providers` shows USD pricing column
- [ ] Fine-tuning acknowledge/decrypt of a large model completes past the 5-minute mark
- [ ] `npm publish --dry-run` reports version `0.8.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)