### PR TITLE
chore(cli): read --version from package.json

### DIFF
--- a/src.ts/cli/cli.ts
+++ b/src.ts/cli/cli.ts
@@ -16,7 +16,7 @@ export const program = new Command()
 program
     .name('0g-compute-cli')
     .description('CLI for interacting with ZG Compute Network')
-    .version('0.8.0')
+    .version(packageJson.version)
 
 ledger(program)
 


### PR DESCRIPTION
## Summary
- The CLI's `--version` string was hardcoded and had drifted to `0.8.0` — it was missed in both the v0.8.1 and v0.8.2 bumps.
- Read it from `package.json` so it stays in sync with the published SDK version automatically.

Should land before publishing v0.8.2 to npm so `0g-compute-cli --version` reports the correct value.

## Test plan
- [ ] `pnpm build`
- [ ] `node cli.commonjs/cli/index.js --version` prints `0.8.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)