### PR TITLE
fix: unblock web-ui browser bundle (stream/promises + ESM banner)

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,12 +17,27 @@ import nodePolyfills from 'rollup-plugin-polyfill-node'
 // installed package (`<pkg>/lib.esm/`) and `findAncestorContaining`
 // correctly resolves `<pkg>/binary/` one level up.
 //
-// See PR #208 review feedback (Bug Report — May 2026, Bug #1).
+// Banner runs at module init in every consumer environment, including
+// browser bundlers. Importing from `url`/`path` here is a trap: browser
+// polyfills like `url@0.11.x` don't expose `fileURLToPath`, so any call
+// crashes on load. Worse, webpack/terser statically infer the `url`
+// module shape and fold away both `typeof` guards and `try/catch` blocks
+// around the call, so defensive wrappers don't survive minification.
+//
+// We avoid the imports entirely and derive `__filename`/`__dirname` from
+// `import.meta.url` with pure string ops:
+//   - In Node ESM (`file:///abs/path/to/lib.esm/index.mjs`) the strip /
+//     drive-letter regex matches what `fileURLToPath` produces.
+//   - In browser bundles, `binary-path.ts` is never invoked, so the
+//     baked-in build-machine path is harmless.
+//
+// See PR #208 review feedback (Bug Report — May 2026, Bug #1) and the
+// follow-up browser-compat issue surfaced by the v0.8.2 web-ui build.
 const esmDirnameShim = [
-    "import { fileURLToPath as __zg_fileURLToPath } from 'url'",
-    "import { dirname as __zg_dirname } from 'path'",
-    'const __filename = __zg_fileURLToPath(import.meta.url)',
-    'const __dirname = __zg_dirname(__filename)',
+    "const __filename = (typeof import.meta !== 'undefined' && typeof import.meta.url === 'string')",
+    "    ? decodeURI(import.meta.url.replace(/^file:\\/\\//, '').replace(/^\\/([A-Za-z]:)/, '$1'))",
+    "    : ''",
+    "const __dirname = __filename ? __filename.replace(/[\\/\\\\][^\\/\\\\]*$/, '') : ''",
 ].join('\n')
 
 export default [

--- a/web-ui/next.config.mjs
+++ b/web-ui/next.config.mjs
@@ -22,6 +22,7 @@ const nextConfig = {
                 tls: false,
                 child_process: false,
                 'fs/promises': false,
+                'stream/promises': false,
                 readline: false,
                 crypto: require.resolve('crypto-browserify'),
                 stream: require.resolve('stream-browserify'),


### PR DESCRIPTION
## Summary
Two browser-bundler issues introduced by #208 / #211 that block `npm publish` (because `prepublishOnly` rebuilds the web-ui).

### 1. `Module not found: Can't resolve 'stream/promises'`
#211 added `import { pipeline } from 'stream/promises'` in the fine-tuning provider download path. Webpack treats `stream/promises` as separate from `stream`, so the existing `stream-browserify` polyfill doesn't cover it.

**Fix:** add `'stream/promises': false` to the webpack `resolve.fallback` in `web-ui/next.config.mjs`. Mirrors the existing `'fs/promises': false`. The fine-tuning TEE download path is Node-only and never executes in the browser.

### 2. `TypeError: fileURLToPath is not a function`
The v0.8.1 ESM banner (#208, Bug #1) imported `fileURLToPath`/`dirname` from `url`/`path` to give Node ESM consumers a real `__dirname`. In a browser bundle webpack resolves `url` to npm `url@0.11.x`, which only exposes `parse/resolve/format/Url` — `fileURLToPath` is undefined and the banner throws at module init.

Defensive guards (`typeof === 'function'`, `try/catch`) **do not survive**: webpack treats `import * as ns from 'url'` as a fully-known module shape and the call gets statically folded back into the bundle.

**Fix:** drop `url`/`path` imports from the banner entirely and derive `__filename`/`__dirname` from `import.meta.url` with pure string ops. On Node ESM the result matches `fileURLToPath` on Linux/macOS, and the leading-slash-before-drive-letter is stripped on Windows. In browser bundles `binary-path.ts` is never invoked, so the build-machine path baked in by the bundler is harmless.

## Verification
- `cd web-ui && pnpm build` succeeds and emits `out/index.html`
- Bundled chunks contain **zero** references to `fileURLToPath`
- Node ESM import of `lib.esm/index.mjs` still loads cleanly
- Regex output matches `url.fileURLToPath()` for the real Node path

Should land before publishing v0.8.2 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)