### PR TITLE
Lazy-load Node.js modules to fix browser bundler issues

### DIFF
--- a/.github/workflows/web-bundler-test.yml
+++ b/.github/workflows/web-bundler-test.yml
@@ -1,0 +1,130 @@
+name: Web Bundler Compatibility
+
+# Regression coverage for browser-bundler consumers of the SDK
+# (PR #216 / v0.8.3). The fixture in `tests/web-bundler-app/` is a minimal
+# Next.js 15 app that imports the SDK from a `'use client'` page. Two
+# production builds run end-to-end:
+#
+#   - Webpack (default `next build`)
+#   - Turbopack (`next build --turbopack`)
+#
+# Both must compile and statically export. A strict ESM stub aliased to
+# `'fs'` makes Turbopack's strict named-export validation catch any
+# top-level `import { … } from 'fs'` reintroduced into the SDK ESM bundle —
+# the exact class of regression that surfaced as "Export createWriteStream
+# / statSync doesn't exist in target module".
+#
+# In addition we run a fast static assertion directly against the built
+# `lib.esm/` output as a belt-and-suspenders check that runs even if the
+# Next.js fixture install/build regresses for unrelated reasons.
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - 'src.ts/**'
+            - 'package.json'
+            - 'pnpm-lock.yaml'
+            - 'rollup.config.mjs'
+            - 'tests/web-bundler-app/**'
+            - '.github/workflows/web-bundler-test.yml'
+    pull_request:
+        branches: [main]
+        paths:
+            - 'src.ts/**'
+            - 'package.json'
+            - 'pnpm-lock.yaml'
+            - 'rollup.config.mjs'
+            - 'tests/web-bundler-app/**'
+            - '.github/workflows/web-bundler-test.yml'
+    workflow_dispatch:
+
+jobs:
+    web-bundler-build:
+        name: Browser bundle build (Next.js 15 / ${{ matrix.bundler }})
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                bundler: [webpack, turbopack]
+            fail-fast: false
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 9.15.4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22.x
+                  cache: 'pnpm'
+
+            - name: Install SDK dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build SDK
+              run: pnpm build
+
+            - name: Static regression assertion (no top-level named/namespace `'fs'` imports)
+              # Catches the same class of bug as the Turbopack build below
+              # but runs in milliseconds and is robust against future
+              # Turbopack behaviour changes. The pattern blocks:
+              #   - `import { … } from 'fs'`        (named imports)
+              #   - `import * as x from 'fs'`        (namespace imports)
+              # These are the import shapes that fail strict ESM named-
+              # export validation when `'fs'` is stubbed to an empty module.
+              # Default imports (`import x from 'fs'`) are NOT blocked: they
+              # bind to the stub's `default` export and survive bundling
+              # (this is what the bundled `adm-zip` dep relies on).
+              # `'fs/promises'`, `'node:fs'`, and other Node specifiers are
+              # also NOT blocked — they are tolerated by the fixture's
+              # permissive CJS stubs and out of scope for this regression.
+              # If you want to add a new top-level named or namespace import
+              # of `'fs'` to the SDK, defer it to runtime via
+              # `await import('fs')` inside an async function instead.
+              run: |
+                  set -eu
+                  echo "Scanning lib.esm/ for forbidden top-level 'fs' imports..."
+                  if grep -nE "^import (\{[^}]*\}|\* as [a-zA-Z_\$][a-zA-Z0-9_\$]*) from 'fs';" lib.esm/*.js; then
+                      echo ""
+                      echo "::error::Found top-level named/namespace import from 'fs' in the SDK ESM bundle."
+                      echo "::error::These break browser bundlers (Turbopack/Vite/strict Webpack) that stub 'fs' to an empty module."
+                      echo "::error::Defer the import to runtime: \`const { foo } = await import('fs')\` inside an async function."
+                      exit 1
+                  fi
+                  echo "OK — no forbidden top-level 'fs' imports found."
+
+            - name: Install fixture dependencies
+              working-directory: tests/web-bundler-app
+              run: npm install --no-audit --no-fund
+
+            - name: Build fixture (${{ matrix.bundler }})
+              working-directory: tests/web-bundler-app
+              run: |
+                  if [ "${{ matrix.bundler }}" = "turbopack" ]; then
+                      npm run build:turbopack
+                  else
+                      npm run build:webpack
+                  fi
+              timeout-minutes: 5
+
+    web-bundler-summary:
+        name: Web bundler test summary
+        runs-on: ubuntu-latest
+        needs: [web-bundler-build]
+        if: always()
+
+        steps:
+            - name: Check build results
+              run: |
+                  if [ "${{ needs.web-bundler-build.result }}" = "success" ]; then
+                      echo "✅ All web-bundler builds passed."
+                  else
+                      echo "❌ Web-bundler builds failed: ${{ needs.web-bundler-build.result }}"
+                      exit 1
+                  fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0gfoundation/0g-compute-ts-sdk",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {

--- a/src.ts/sdk/fine-tuning/provider/provider.ts
+++ b/src.ts/sdk/fine-tuning/provider/provider.ts
@@ -1,7 +1,6 @@
 import type { FineTuningServingContract } from '../contract'
 import axios from 'axios'
 import { ethers } from 'ethers'
-import { createWriteStream } from 'fs'
 import * as fs from 'fs/promises'
 import * as path from 'path'
 import type { Readable } from 'stream'
@@ -421,6 +420,7 @@ export class Provider {
                         lastChunkAt = Date.now()
                     })
 
+                    const { createWriteStream } = await import('fs')
                     const writer = createWriteStream(destFile)
                     await pipeline(stream, writer)
 

--- a/src.ts/sdk/fine-tuning/token/token.ts
+++ b/src.ts/sdk/fine-tuning/token/token.ts
@@ -56,7 +56,7 @@ export async function calculateTokenSizeViaExe(
     const { download } = await safeDynamicImport()
 
     const binaryPathModule = await import('../zg-storage/binary-path')
-    const executorDir = binaryPathModule.getBinaryDir()
+    const executorDir = await binaryPathModule.getBinaryDir()
     const binaryFile = path.join(executorDir, 'token_counter')
 
     let needDownload = false
@@ -122,7 +122,7 @@ export async function calculateTokenSizeViaPython(
         }
     }
     const binaryPathModule = await import('../zg-storage/binary-path')
-    const projectRoot = binaryPathModule.getPackageRoot()
+    const projectRoot = await binaryPathModule.getPackageRoot()
     return await calculateTokenSize(
         tokenizerRootHash,
         datasetPath,

--- a/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
+++ b/src.ts/sdk/fine-tuning/zg-storage/binary-path.ts
@@ -48,8 +48,17 @@
  *     output `__dirname` is always defined and the fallback is unused.
  */
 
-import * as fs from 'fs'
-import * as path from 'path'
+// `fs` and `path` are loaded lazily inside the async helpers below rather
+// than via top-level static imports. Browser bundlers (Webpack, Turbopack,
+// Vite) statically analyse the top-level `import`s of any module reachable
+// from the SDK entry; with the SDK's `package.json` `"browser": { "fs": false,
+// "path": false }` mapping they stub the modules to empty objects and then
+// raise "Export statSync doesn't exist in target module" on the static
+// `fs.statSync(...)` access. Dynamic `await import('fs')` inside a function
+// that only ever runs on Node (this whole module is gated behind the
+// fine-tuning binary-execution paths) sidesteps that analysis while keeping
+// the actual Node behaviour identical.
+import type { Stats } from 'fs'
 
 /**
  * Best-effort directory anchor for the running module.
@@ -77,7 +86,12 @@ function getAnchorDir(): string {
  * named `marker`. Returns the absolute path of the ancestor, or `null` if
  * no such ancestor exists before reaching the filesystem root.
  */
-function findAncestorContaining(start: string, marker: string): string | null {
+async function findAncestorContaining(
+    start: string,
+    marker: string
+): Promise<string | null> {
+    const fs = await import('fs')
+    const path = await import('path')
     let dir = start
     for (let i = 0; i < 32; i++) {
         const candidate = path.join(dir, marker)
@@ -107,7 +121,7 @@ let cachedRoot: string | null | undefined
  * installed without the binary, e.g. someone copied only `lib.commonjs/`
  * out of `node_modules`).
  */
-export function getPackageRoot(): string {
+export async function getPackageRoot(): Promise<string> {
     if (cachedRoot !== undefined) {
         if (cachedRoot === null) {
             throw new Error(
@@ -119,7 +133,7 @@ export function getPackageRoot(): string {
         }
         return cachedRoot
     }
-    const found = findAncestorContaining(getAnchorDir(), 'binary')
+    const found = await findAncestorContaining(getAnchorDir(), 'binary')
     cachedRoot = found
     if (cachedRoot === null) {
         return getPackageRoot()
@@ -130,8 +144,9 @@ export function getPackageRoot(): string {
 /**
  * Returns the absolute path of the bundled `binary/` directory.
  */
-export function getBinaryDir(): string {
-    return path.join(getPackageRoot(), 'binary')
+export async function getBinaryDir(): Promise<string> {
+    const path = await import('path')
+    return path.join(await getPackageRoot(), 'binary')
 }
 
 /**
@@ -144,9 +159,11 @@ export function getBinaryDir(): string {
  * binaries are added (Bug #2). The error spells out the workaround so a
  * developer is not left staring at a generic `ENOENT` or `ENOEXEC`.
  */
-export function getBundledBinary(name: string): string {
-    const candidate = path.join(getBinaryDir(), name)
-    let stats: fs.Stats
+export async function getBundledBinary(name: string): Promise<string> {
+    const fs = await import('fs')
+    const path = await import('path')
+    const candidate = path.join(await getBinaryDir(), name)
+    let stats: Stats
     try {
         stats = fs.statSync(candidate)
     } catch (err) {

--- a/src.ts/sdk/fine-tuning/zg-storage/zg-storage.ts
+++ b/src.ts/sdk/fine-tuning/zg-storage/zg-storage.ts
@@ -23,8 +23,8 @@ export async function upload(
         const rpcUrl = config?.rpcUrl || ZG_RPC_ENDPOINT_TESTNET
         const indexerUrl = config?.indexerUrl || INDEXER_URL_TESTNET_TURBO
 
+        const command = await getBundledBinary('0g-storage-client')
         return new Promise((resolve, reject) => {
-            const command = getBundledBinary('0g-storage-client')
             const args = [
                 'upload',
                 '--url',
@@ -103,9 +103,8 @@ export async function download(
     // Use provided config or default to testnet
     const indexerUrl = config?.indexerUrl || INDEXER_URL_TESTNET_TURBO
 
+    const command = await getBundledBinary('0g-storage-client')
     return new Promise((resolve, reject) => {
-        const command = getBundledBinary('0g-storage-client')
-
         const args = [
             'download',
             '--file',

--- a/tests/web-bundler-app/.gitignore
+++ b/tests/web-bundler-app/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+next-env.d.ts
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/tests/web-bundler-app/app/layout.tsx
+++ b/tests/web-bundler-app/app/layout.tsx
@@ -1,0 +1,15 @@
+export const metadata = {
+    title: 'web-bundler-app',
+}
+
+export default function RootLayout({
+    children,
+}: {
+    children: React.ReactNode
+}) {
+    return (
+        <html lang="en">
+            <body>{children}</body>
+        </html>
+    )
+}

--- a/tests/web-bundler-app/app/page.tsx
+++ b/tests/web-bundler-app/app/page.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+// Pulls the entire SDK surface into the client bundle so the Node-only
+// transitive deps (fine-tuning provider, zg-storage, binary-path, etc.) all
+// have to survive browser-bundler analysis. The actual values are inspected
+// via `typeof` so the bundler can't tree-shake them away.
+import {
+    createZGComputeNetworkBroker,
+    FineTuningBroker,
+    InferenceBroker,
+    LedgerBroker,
+} from '@0gfoundation/0g-compute-ts-sdk'
+
+export default function Page() {
+    const probes = [
+        typeof createZGComputeNetworkBroker,
+        typeof FineTuningBroker,
+        typeof InferenceBroker,
+        typeof LedgerBroker,
+    ].join(',')
+    return <pre>{probes}</pre>
+}

--- a/tests/web-bundler-app/next.config.mjs
+++ b/tests/web-bundler-app/next.config.mjs
@@ -1,0 +1,80 @@
+// Regression fixture for browser-bundler compatibility of the SDK's ESM
+// bundle. Two builds run against this app in CI:
+//
+//   - `next build` (Webpack)         — the established consumer setup, mirrors
+//                                       the configuration used by web-ui/.
+//   - `next build --turbopack`       — the strict ESM-aware bundler that
+//                                       originally surfaced the
+//                                       "Export createWriteStream / statSync
+//                                       doesn't exist in target module" bug.
+//
+// Both builds must succeed for the SDK to be considered browser-safe.
+
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+// Turbopack `resolveAlias` interprets string values as paths relative to the
+// project root (the leading `./` is required). Absolute paths get prefixed
+// with `.` and treated relative, which fails to resolve.
+//
+// Two stubs by design:
+//
+//   - `fs-strict.mjs` is an ESM module with NO named exports. Aliased ONLY
+//     to the bare `'fs'` specifier, it forces Turbopack's strict named-
+//     export validation to flag any top-level `import { … } from 'fs'` or
+//     statically-resolved `fs.<symbol>` access that creeps back into the
+//     SDK bundle. This is the regression check for PR #216.
+//   - `node-permissive.cjs` is a CJS empty module. Aliased to the other
+//     Node-only specifiers (`fs/promises`, `stream/promises`,
+//     `child_process`, `readline`, `net`, `tls`) where the SDK currently
+//     does have legitimate top-level imports we are not policing here.
+const fsStrict = './stubs/fs-strict.mjs'
+const nodePermissive = './stubs/node-permissive.cjs'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+    reactStrictMode: false,
+    transpilePackages: ['@0gfoundation/0g-compute-ts-sdk'],
+    output: 'export',
+    images: { unoptimized: true },
+
+    // Webpack: stub Node-only modules to `false` (empty module) and provide
+    // browser polyfills for the modules we do need on the client. Mirrors the
+    // setup in web-ui/next.config.mjs.
+    webpack: (config, { isServer }) => {
+        if (!isServer) {
+            config.resolve.fallback = {
+                ...config.resolve.fallback,
+                fs: false,
+                net: false,
+                tls: false,
+                child_process: false,
+                'fs/promises': false,
+                'stream/promises': false,
+                readline: false,
+                crypto: require.resolve('crypto-browserify'),
+                stream: require.resolve('stream-browserify'),
+                buffer: require.resolve('buffer/'),
+                util: require.resolve('util/'),
+            }
+        }
+        return config
+    },
+
+    // Turbopack: `resolveAlias` is the analogue of webpack's
+    // `resolve.fallback`. There is no `false` shorthand, so every Node-only
+    // module is aliased to the local empty stub.
+    turbopack: {
+        resolveAlias: {
+            fs: fsStrict,
+            'fs/promises': nodePermissive,
+            'stream/promises': nodePermissive,
+            child_process: nodePermissive,
+            readline: nodePermissive,
+            net: nodePermissive,
+            tls: nodePermissive,
+        },
+    },
+}
+
+export default nextConfig

--- a/tests/web-bundler-app/package.json
+++ b/tests/web-bundler-app/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "web-bundler-app",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Regression fixture: ensures @0gfoundation/0g-compute-ts-sdk can be consumed by a Next.js 15 browser build under both Turbopack and Webpack.",
+    "scripts": {
+        "build:webpack": "next build",
+        "build:turbopack": "next build --turbopack"
+    },
+    "dependencies": {
+        "@0gfoundation/0g-compute-ts-sdk": "file:../..",
+        "next": "15.5.18",
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
+    },
+    "devDependencies": {
+        "@types/node": "20.14.0",
+        "@types/react": "18.3.12",
+        "@types/react-dom": "18.3.1",
+        "buffer": "6.0.3",
+        "crypto-browserify": "3.12.0",
+        "stream-browserify": "3.0.0",
+        "typescript": "5.4.5",
+        "util": "0.12.5"
+    }
+}

--- a/tests/web-bundler-app/stubs/fs-strict.mjs
+++ b/tests/web-bundler-app/stubs/fs-strict.mjs
@@ -1,0 +1,24 @@
+// STRICT empty ESM stub specifically for the `'fs'` module.
+//
+// This is the regression-test linchpin for the v0.8.2 → v0.8.3 fix
+// (PR #216): the SDK previously had top-level
+//   - `import { createWriteStream } from 'fs'`     (provider.ts)
+//   - `import * as fs from 'fs'` + `fs.statSync(…)` (binary-path.ts)
+// which surfaced as Turbopack errors:
+//   - "Export createWriteStream doesn't exist in target module"
+//   - "Export statSync doesn't exist in target module"
+// once `'fs'` was aliased away from the real Node builtin in a browser
+// build. The fix moved both to lazy `await import('fs')` inside Node-only
+// async functions, so the SDK's ESM bundle no longer carries any top-level
+// import from `'fs'`.
+//
+// We keep this stub as ESM with an empty default export and ZERO named
+// exports on purpose: Turbopack performs strict named-export validation
+// against ESM modules. If anyone reintroduces a top-level
+// `import { … } from 'fs'` (or `import * as fs from 'fs'` followed by a
+// statically-resolved `fs.<symbol>` access) the build fails here, with the
+// same error class the original bug report carried.
+//
+// DO NOT add named exports to this file to "fix" a build failure — fix the
+// SDK by deferring the import to runtime instead.
+export default {}

--- a/tests/web-bundler-app/stubs/node-permissive.cjs
+++ b/tests/web-bundler-app/stubs/node-permissive.cjs
@@ -1,0 +1,18 @@
+// PERMISSIVE CJS empty stub for non-`fs` Node-only modules
+// (`fs/promises`, `stream/promises`, `child_process`, `readline`, `net`,
+// `tls`).
+//
+// CJS is intentional: Turbopack treats a CJS module's export shape as
+// dynamic and does not statically validate named imports against it. That
+// is what we want HERE — these modules legitimately have top-level static
+// imports in the current SDK ESM bundle (e.g.
+// `import * as fs$1 from 'fs/promises'`,
+// `import { pipeline } from 'stream/promises'`,
+// `import { spawn } from 'child_process'`). They are not what the
+// user-reported regression was about, and constraining them strictly would
+// make this fixture flag pre-existing, accepted SDK behaviour as a failure.
+//
+// The strict-ESM check that catches the regression class lives in
+// `./fs-strict.mjs`, which is aliased only for the `'fs'` module.
+module.exports = {}
+module.exports.default = {}

--- a/tests/web-bundler-app/tsconfig.json
+++ b/tests/web-bundler-app/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
Convert top-level static imports of Node.js modules (`fs`, `path`) to dynamic lazy-loaded imports within async functions. This prevents browser bundlers (Webpack, Turbopack, Vite) from attempting to stub these modules and raising "Export doesn't exist" errors during static analysis.

## Key Changes
- **binary-path.ts**: 
  - Removed top-level `import * as fs` and `import * as path` statements
  - Added dynamic `await import('fs')` and `await import('path')` calls inside async functions
  - Converted `findAncestorContaining()`, `getPackageRoot()`, and `getBundledBinary()` to async functions
  - Changed `getBinaryDir()` to async function
  - Added `import type { Stats }` for type-only import of `fs.Stats`

- **zg-storage.ts**:
  - Moved `getBundledBinary()` calls outside Promise constructors to properly await them
  - Ensures async function calls are awaited before being used

- **token.ts**:
  - Updated calls to `getBinaryDir()` and `getPackageRoot()` to use `await` operator

- **provider.ts**:
  - Removed top-level `import { createWriteStream } from 'fs'`
  - Added dynamic `await import('fs')` inside the function where `createWriteStream` is used

- **package.json**: Bumped version from 0.8.2 to 0.8.3

## Implementation Details
The changes leverage the fact that this code only runs on Node.js (gated behind fine-tuning binary-execution paths). Dynamic imports inside functions sidestep static analysis by browser bundlers while maintaining identical Node.js behavior. The `package.json` `"browser"` field already maps `fs` and `path` to `false`, so this approach ensures those modules are never analyzed in browser contexts.

https://claude.ai/code/session_018Qe9jMo5W6KvWEEuAbNaYM