### PR TITLE
fix(cli): support fractional tier multipliers in price display

### DIFF
--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -23,6 +23,16 @@ function formatTokenCount(tokens: number): string {
     return `${tokens}`
 }
 
+// Multiply a bigint wei price by a fractional multiplier (e.g. 1.333) without
+// losing precision. Scales the multiplier to a 6-decimal fixed-point integer
+// before BigInt multiplication, then divides back out with round-half-up.
+const MULTIPLIER_SCALE = 1_000_000n
+function applyMultiplier(base: bigint, mul: number): bigint {
+    const scaled = BigInt(Math.round(mul * Number(MULTIPLIER_SCALE)))
+    const product = base * scaled
+    return (product + MULTIPLIER_SCALE / 2n) / MULTIPLIER_SCALE
+}
+
 /**
  * Format a price value, trimming unnecessary trailing zeros while keeping
  * enough precision to distinguish non-zero values.
@@ -50,9 +60,9 @@ function pushTieredPricingRows(
         const rangeLabel = tier.maxInputTokens === 0
             ? `>${prevLabel}`
             : `${prevLabel}-${formatTokenCount(tier.maxInputTokens)}`
-        const effectiveInputPrice = baseInputPrice * BigInt(tier.inputMultiplier)
+        const effectiveInputPrice = applyMultiplier(baseInputPrice, tier.inputMultiplier)
         const inPrice = formatPrice(effectiveInputPrice)
-        const outPrice = formatPrice(baseOutputPrice * BigInt(tier.outputMultiplier))
+        const outPrice = formatPrice(applyMultiplier(baseOutputPrice, tier.outputMultiplier))
         let priceStr = `In: ${inPrice} / Out: ${outPrice}`
         if (cacheBilling) {
             const cachePrice = formatPrice(effectiveInputPrice / BigInt(cacheBilling.divisor))


### PR DESCRIPTION
## Summary

- The inference CLI built effective tier prices via `baseInputPrice * BigInt(tier.inputMultiplier)`, which throws `The number 1.333 cannot be converted to a BigInt because it is not an integer` once the broker started emitting fractional tier multipliers (e.g. `1.333` / `1.166` for Alibaba glm-5.1 tiered pricing).
- Added an `applyMultiplier(base, mul)` helper that scales the multiplier to a 6-decimal fixed-point integer before `BigInt` multiplication and divides back out with round-half-up — wei-denominated base prices keep full precision under fractional multipliers.

## Repro (before fix)

```
$ 0g-compute-cli list
✗ Operation failed: The number 1.333 cannot be converted to a BigInt because it is not an integer
```

(triggered when any provider's `tieredPricing` carries a non-integer multiplier)

## Notes

The wire-level types (`input_multiplier` / `output_multiplier`) were already typed as `number` in `read-only-model.ts`, so only the CLI display path needed fixing.

Paired with broker-side fix: https://github.com/0gfoundation/0g-serving-broker/pull/506

## Test plan

- [x] `npx tsc -p tsconfig.cli.json --noEmit`
- [ ] `npm run build` then run `0g-compute-cli` against a provider that publishes fractional tier multipliers; verify the table shows correct `>32k tokens` row prices (≈ base × 1.333 input / × 1.166 output for glm-5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)