### PR TITLE
feat(inference): multi-model provider support (list, get-models, select)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ if (catalog.multiModel) {
     )
 }
 
-// Select a specific model (the broker validates it and bills that model's price)
+// Select a specific model (forwarded as-is; the provider validates it and bills that model's price)
 const { endpoint, model } = await broker.inference.getServiceMetadata(
     providerAddress,
     'zai-org/GLM-5.1-FP8' // one of catalog.models[].id

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ await broker.ledger.depositFund(10)
 // Acknowledge provider
 await broker.inference.acknowledgeProviderSigner(providerAddress)
 
-// Get service metadata
+// Get service metadata. `model` here is the provider's DEFAULT model.
+// A provider may serve multiple models — see "Multi-model providers" below to
+// list them and select a specific one.
 const { endpoint, model } =
     await broker.inference.getServiceMetadata(providerAddress)
 
@@ -163,6 +165,43 @@ if (job.status === 'failed') throw new Error(job.errorMessage)
 
 // job.data — raw provider response, e.g. { data: [{ b64_json: "..." }] }
 ```
+
+### Multi-model providers
+
+A single provider can serve **multiple models** behind one address (each with
+its own pricing). `getServiceMetadata()` returns only the provider's *default*
+model; use `getProviderModels()` to discover the full catalog, then pass the
+chosen model id to `getServiceMetadata(addr, modelId)` (or set it as `model` in
+the request body).
+
+```typescript
+// Discover the models a provider serves (live, from its /v1/models endpoint)
+const catalog = await broker.inference.getProviderModels(providerAddress)
+if (catalog.multiModel) {
+    catalog.models.forEach((m) =>
+        console.log(m.id, m.canonical_id ?? '', m.type ?? '')
+    )
+}
+
+// Select a specific model (the broker validates it and bills that model's price)
+const { endpoint, model } = await broker.inference.getServiceMetadata(
+    providerAddress,
+    'zai-org/GLM-5.1-FP8' // one of catalog.models[].id
+)
+const headers = await broker.inference.getRequestHeaders(providerAddress)
+await fetch(`${endpoint}/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify({
+        model, // the selected model
+        messages: [{ role: 'user', content: 'Hello!' }],
+    }),
+})
+```
+
+The CLI mirrors this: `0g-compute-cli inference list-providers` marks multi-model
+providers, and `0g-compute-cli inference get-models --provider <addr>` lists a
+provider's models.
 
 ## Direct API Access
 

--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -11,7 +11,7 @@ import axios from 'axios'
 import fs from 'fs'
 import { ethers } from 'ethers'
 import { formatError } from '../sdk/common/utils/error-handler'
-import { parseTieredPricing, parseCacheTokenBilling } from '../sdk/inference'
+import { parseTieredPricing, parseCacheTokenBilling, parseMultiModelInfo } from '../sdk/inference'
 import type { TieredPricingInfo, CacheTokenBillingInfo } from '../sdk/inference'
 
 /**
@@ -156,7 +156,22 @@ export default function inference(program: Command) {
                         chalk.blue(`Provider ${index + 1}`),
                         chalk.blue(service.provider),
                     ])
-                    table.push(['Model', service.model || 'N/A'])
+                    // Multi-model providers serve N models behind one address;
+                    // the on-chain `model` is only the default. Surface the flag
+                    // and point to `get-models` for the full catalog.
+                    const multi = parseMultiModelInfo(service.additionalInfo)
+                    if (multi.multiModel) {
+                        table.push([
+                            'Models',
+                            chalk.green(
+                                `multi-model${multi.priceDenomination ? ` (${multi.priceDenomination})` : ''}`
+                            ) +
+                                `\ndefault: ${service.model || 'N/A'}` +
+                                `\n→ get-models --provider ${service.provider}`,
+                        ])
+                    } else {
+                        table.push(['Model', service.model || 'N/A'])
+                    }
 
 
                     // Check for tiered pricing and cache billing in additionalInfo
@@ -226,6 +241,63 @@ export default function inference(program: Command) {
                         service.verifiability || 'N/A',
                     ])
                 })
+                console.log(table.toString())
+            })
+        })
+
+    program
+        .command('get-models')
+        .description(
+            "Get the models a provider serves (live from its /v1/models endpoint)"
+        )
+        .requiredOption('--provider <address>', 'Provider address')
+        .option('--rpc <url>', '0G Chain RPC endpoint')
+        .option('--ledger-ca <address>', 'Account (ledger) contract address')
+        .option('--inference-ca <address>', 'Inference contract address')
+        .action(async (options: any) => {
+            await withROBroker(options, async (broker) => {
+                const result = await broker.inference.getProviderModels(
+                    options.provider
+                )
+                console.log(chalk.blue(`Provider:      ${result.provider}`))
+                console.log(
+                    `Multi-model:   ${result.multiModel ? chalk.green('yes') : 'no'}` +
+                        (result.priceDenomination
+                            ? ` (${result.priceDenomination})`
+                            : '')
+                )
+                console.log(`Default model: ${result.defaultModel || 'N/A'}`)
+
+                if (result.models.length === 0) {
+                    console.log(
+                        chalk.yellow(
+                            'No models returned by the provider /v1/models endpoint.'
+                        )
+                    )
+                    return
+                }
+
+                const table = new Table({
+                    head: ['Model ID', 'Canonical', 'Type', 'Pricing'],
+                    colWidths: [32, 18, 18, 40],
+                    wordWrap: true,
+                })
+                for (const m of result.models) {
+                    let pricing = 'N/A'
+                    if (m.pricing?.video) {
+                        pricing = `${m.pricing.video} / sec`
+                    } else if (m.pricing?.image) {
+                        pricing = `${m.pricing.image} / image`
+                    } else if (m.pricing?.prompt || m.pricing?.completion) {
+                        pricing = `in ${m.pricing.prompt ?? '-'} / out ${m.pricing.completion ?? '-'} (per token)`
+                    }
+                    table.push([
+                        m.id,
+                        m.canonical_id ?? '-',
+                        m.type ?? '-',
+                        pricing,
+                    ])
+                }
                 console.log(table.toString())
             })
         })

--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -12,7 +12,7 @@ import fs from 'fs'
 import { ethers } from 'ethers'
 import { formatError } from '../sdk/common/utils/error-handler'
 import { parseTieredPricing, parseCacheTokenBilling, parseMultiModelInfo } from '../sdk/inference'
-import type { TieredPricingInfo, CacheTokenBillingInfo } from '../sdk/inference'
+import type { TieredPricingInfo, CacheTokenBillingInfo, ProviderModelInfo, ServiceHealthMetric } from '../sdk/inference'
 
 /**
  * Format a token count for display (e.g., 256000 -> "256k", 1000000 -> "1M")
@@ -73,6 +73,135 @@ function pushTieredPricingRows(
             prevLabel = formatTokenCount(tier.maxInputTokens)
         }
     }
+}
+
+/**
+ * Render a numeric price for display, dropping float artifacts. Returns '-' for
+ * missing/non-finite values.
+ */
+function fmtPrice(value: number | undefined): string {
+    if (value === undefined || !Number.isFinite(value)) return '-'
+    return value.toLocaleString('en-US', {
+        maximumFractionDigits: 20,
+        useGrouping: false,
+    })
+}
+
+/**
+ * Build the multi-line pricing cell for a model in `get-models`. Shows the base
+ * per-token (or per-image / per-second) price plus any tiered pricing and
+ * cache-hit discount the provider advertises in /v1/models, mirroring the
+ * tiered/cache rows `list-providers` shows so the two views stay consistent.
+ *
+ * @param m - The model entry from /v1/models.
+ * @param useUsd - When true, base prices come from `pricing_usd` (decimal USD,
+ *   used as-is). Otherwise from native `pricing`, whose values are in neuron and
+ *   are converted to 0G for display (mirroring `list-providers`). Tiered
+ *   multipliers and the cache divisor are unit-independent, so they're sourced
+ *   from whichever object carries them (a provider commonly attaches them to
+ *   native `pricing` only) and applied to the displayed base prices.
+ */
+function formatModelPricing(m: ProviderModelInfo, useUsd: boolean): string {
+    const base = useUsd ? m.pricing_usd : m.pricing
+    const alt = useUsd ? m.pricing : m.pricing_usd
+    if (!base) return 'N/A'
+
+    // USD prices are decimal strings; native prices are neuron integers that
+    // must be converted to 0G for a human-readable per-token figure.
+    const toDisplay = (v?: string): number | undefined => {
+        if (v === undefined || v === null) return undefined
+        if (useUsd) {
+            const n = Number(v)
+            return Number.isFinite(n) ? n : undefined
+        }
+        try {
+            return neuronToA0gi(BigInt(v))
+        } catch {
+            const n = Number(v)
+            return Number.isFinite(n) ? n : undefined
+        }
+    }
+
+    if (base.video !== undefined) return `${fmtPrice(toDisplay(base.video))} / sec`
+    if (base.image !== undefined) return `${fmtPrice(toDisplay(base.image))} / image`
+
+    const inBase = toDisplay(base.prompt)
+    const outBase = toDisplay(base.completion)
+    if (inBase === undefined && outBase === undefined) return 'N/A'
+
+    const lines = [`in ${fmtPrice(inBase)} / out ${fmtPrice(outBase)} per token`]
+
+    const cache = base.cache_token_billing ?? alt?.cache_token_billing
+    if (cache && cache.divisor > 0 && inBase !== undefined) {
+        lines.push(`cache-hit in: ${fmtPrice(inBase / cache.divisor)}`)
+    }
+
+    const tiers = base.tiered_pricing ?? alt?.tiered_pricing
+    if (Array.isArray(tiers) && tiers.length > 0) {
+        lines.push('tiered by input tokens:')
+        let prevLabel = '0'
+        for (const tier of tiers) {
+            const rangeLabel =
+                tier.max_input_tokens === 0
+                    ? `>${prevLabel}`
+                    : `${prevLabel}-${formatTokenCount(tier.max_input_tokens)}`
+            const tin =
+                inBase !== undefined
+                    ? fmtPrice(inBase * tier.input_multiplier)
+                    : '-'
+            const tout =
+                outBase !== undefined
+                    ? fmtPrice(outBase * tier.output_multiplier)
+                    : '-'
+            lines.push(`  ${rangeLabel}: in ${tin} / out ${tout}`)
+            if (tier.max_input_tokens !== 0) {
+                prevLabel = formatTokenCount(tier.max_input_tokens)
+            }
+        }
+    }
+
+    return lines.join('\n')
+}
+
+/**
+ * Build the per-model Health cell for `get-models` from the status-API metric
+ * merged onto the model. Shows status, uptime, and average response latency.
+ * Returns '-' when the status API has no metric for this (provider, model).
+ */
+function formatModelHealth(health?: ServiceHealthMetric): string {
+    if (!health) return '-'
+
+    let statusLine: string
+    if (health.status === 'healthy') {
+        statusLine = chalk.green('✓ healthy')
+    } else if (health.status === 'warning') {
+        statusLine = chalk.yellow('⚠ warning')
+    } else if (health.status === 'critical') {
+        statusLine = chalk.red('✗ critical')
+    } else {
+        statusLine = chalk.gray('? unknown')
+    }
+
+    const lines = [statusLine]
+
+    const uptime = health.checks?.uptime
+    if (typeof uptime === 'number') {
+        const pct = `${uptime}% up`
+        lines.push(
+            uptime >= 85
+                ? chalk.green(pct)
+                : uptime >= 70
+                    ? chalk.yellow(pct)
+                    : chalk.red(pct)
+        )
+    }
+
+    const resp = health.performance?.response_time
+    if (resp && typeof resp.avg === 'number') {
+        lines.push(`${Math.round(resp.avg)}${resp.unit || 'ms'} resp`)
+    }
+
+    return lines.join('\n')
 }
 
 async function promptDurationSelection(): Promise<number> {
@@ -144,6 +273,7 @@ export default function inference(program: Command) {
         .action(async (options: any) => {
             const table = new Table({
                 colWidths: [40, 60],
+                wordWrap: true,
             })
             await withROBroker(options, async (broker) => {
                 const services = await broker.inference.listService(
@@ -166,8 +296,7 @@ export default function inference(program: Command) {
                             chalk.green(
                                 `multi-model${multi.priceDenomination ? ` (${multi.priceDenomination})` : ''}`
                             ) +
-                                `\ndefault: ${service.model || 'N/A'}` +
-                                `\n→ get-models --provider ${service.provider}`,
+                                `\nRun: 0g-compute-cli inference get-models --provider ${service.provider}`,
                         ])
                     } else {
                         table.push(['Model', service.model || 'N/A'])
@@ -277,25 +406,24 @@ export default function inference(program: Command) {
                     return
                 }
 
+                // Mirror the denomination shown by `list-providers`: a provider
+                // priced in USD advertises priceDenomination "USD" on-chain, so
+                // surface its USD prices; otherwise fall back to native-token (0G)
+                // prices. Keeping the unit consistent across both commands avoids
+                // the "is this USD or 0G?" ambiguity the bare numbers caused.
+                const useUsd = result.priceDenomination === 'USD'
+                const priceUnit = useUsd ? 'USD' : '0G'
                 const table = new Table({
-                    head: ['Model ID', 'Canonical', 'Type', 'Pricing'],
-                    colWidths: [32, 18, 18, 40],
+                    head: ['Model', 'Type', `Pricing (${priceUnit})`, 'Health'],
+                    colWidths: [24, 10, 44, 20],
                     wordWrap: true,
                 })
                 for (const m of result.models) {
-                    let pricing = 'N/A'
-                    if (m.pricing?.video) {
-                        pricing = `${m.pricing.video} / sec`
-                    } else if (m.pricing?.image) {
-                        pricing = `${m.pricing.image} / image`
-                    } else if (m.pricing?.prompt || m.pricing?.completion) {
-                        pricing = `in ${m.pricing.prompt ?? '-'} / out ${m.pricing.completion ?? '-'} (per token)`
-                    }
                     table.push([
                         m.id,
-                        m.canonical_id ?? '-',
                         m.type ?? '-',
-                        pricing,
+                        formatModelPricing(m, useUsd),
+                        formatModelHealth(m.healthMetrics),
                     ])
                 }
                 console.log(table.toString())
@@ -317,6 +445,7 @@ export default function inference(program: Command) {
         .action(async (options: any) => {
             const table = new Table({
                 colWidths: [40, 60],
+                wordWrap: true,
             })
             await withROBroker(options, async (broker) => {
                 const services = await broker.inference.listServiceWithDetail(
@@ -332,7 +461,21 @@ export default function inference(program: Command) {
                         chalk.blue(`Provider ${index + 1}`),
                         chalk.blue(service.provider),
                     ])
-                    table.push(['Model', service.model || 'N/A'])
+                    // Multi-model providers serve N models behind one address;
+                    // the on-chain `model` is only the default. Surface the flag
+                    // and point to `get-models` for the full catalog (mirrors
+                    // `list-providers`).
+                    if (service.multiModel) {
+                        table.push([
+                            'Models',
+                            chalk.green(
+                                `multi-model${service.priceDenomination ? ` (${service.priceDenomination})` : ''}`
+                            ) +
+                                `\nRun: 0g-compute-cli inference get-models --provider ${service.provider}`,
+                        ])
+                    } else {
+                        table.push(['Model', service.model || 'N/A'])
+                    }
 
                     // Human-readable model name and description from /v1/models
                     if (modelInfo?.name) {
@@ -382,15 +525,7 @@ export default function inference(program: Command) {
                     const isSpeechService =
                         service.serviceType === 'speech-to-text'
 
-                    if (service.tieredPricing && !isImageService && !isSpeechService) {
-                        pushTieredPricingRows(
-                            table,
-                            BigInt(service.inputPrice),
-                            BigInt(service.outputPrice),
-                            service.tieredPricing,
-                            service.cacheTokenBilling
-                        )
-                    } else if (isSpeechService) {
+                    if (isSpeechService) {
                         // Speech-to-text is billed per second of audio against inputPrice
                         table.push([
                             'Price Per Second (0G)',
@@ -400,52 +535,77 @@ export default function inference(program: Command) {
                                 ).toFixed(18)
                                 : 'N/A',
                         ])
+                    } else if (service.priceDenomination === 'USD' && modelInfo?.pricing_usd) {
+                        // USD-denominated provider: show USD prices (incl. tiered
+                        // and cache) in one consolidated cell, consistent with
+                        // `list-providers` (which flags "(USD)") and `get-models`.
+                        // Tiered multipliers / cache divisor are unit-independent
+                        // and fall back to the native `pricing` object inside
+                        // formatModelPricing.
+                        table.push([
+                            'Pricing (USD)',
+                            formatModelPricing(modelInfo, true),
+                        ])
                     } else {
-                        if (!isImageService) {
+                        // Native (0G) display. Also the fallback for a USD provider
+                        // whose per-model USD pricing the status API didn't carry —
+                        // the multi-model header already flags USD and points to
+                        // `get-models` for authoritative per-model USD prices.
+                        if (service.tieredPricing && !isImageService) {
+                            pushTieredPricingRows(
+                                table,
+                                BigInt(service.inputPrice),
+                                BigInt(service.outputPrice),
+                                service.tieredPricing,
+                                service.cacheTokenBilling
+                            )
+                        } else {
+                            if (!isImageService) {
+                                table.push([
+                                    'Input Price Per Token (0G)',
+                                    service.inputPrice
+                                        ? neuronToA0gi(
+                                            BigInt(service.inputPrice)
+                                        ).toFixed(18)
+                                        : 'N/A',
+                                ])
+                            }
+
+                            const outputPriceLabel = isImageService
+                                ? 'Price Per Image (OG)'
+                                : 'Output Price Per Token (0G)'
+
                             table.push([
-                                'Input Price Per Token (0G)',
-                                service.inputPrice
+                                outputPriceLabel,
+                                service.outputPrice
                                     ? neuronToA0gi(
-                                        BigInt(service.inputPrice)
+                                        BigInt(service.outputPrice)
                                     ).toFixed(18)
                                     : 'N/A',
                             ])
-                        }
 
-                        const outputPriceLabel = isImageService
-                            ? 'Price Per Image (OG)'
-                            : 'Output Price Per Token (0G)'
-
-                        table.push([
-                            outputPriceLabel,
-                            service.outputPrice
-                                ? neuronToA0gi(
-                                    BigInt(service.outputPrice)
+                            // Show cache hit price for flat pricing (non-image services)
+                            if (service.cacheTokenBilling && !isImageService && service.inputPrice) {
+                                const cacheHitPrice = neuronToA0gi(
+                                    BigInt(service.inputPrice) / BigInt(service.cacheTokenBilling.divisor)
                                 ).toFixed(18)
-                                : 'N/A',
-                        ])
-
-                        // Show cache hit price for flat pricing (non-image services)
-                        if (service.cacheTokenBilling && !isImageService && service.inputPrice) {
-                            const cacheHitPrice = neuronToA0gi(
-                                BigInt(service.inputPrice) / BigInt(service.cacheTokenBilling.divisor)
-                            ).toFixed(18)
-                            table.push(['Cache Hit Price Per Token (0G)', cacheHitPrice])
+                                table.push(['Cache Hit Price Per Token (0G)', cacheHitPrice])
+                            }
                         }
-                    }
 
-                    const pricingUSD = modelInfo?.pricing_usd
-                    if (pricingUSD) {
-                        if (!isImageService && pricingUSD.prompt) {
-                            table.push(['Input Price Per Token (USD)', pricingUSD.prompt])
-                        }
-                        if (pricingUSD.image) {
-                            table.push(['Price Per Image (USD)', pricingUSD.image])
-                        } else if (pricingUSD.completion) {
-                            const usdLabel = isImageService
-                                ? 'Price Per Image (USD)'
-                                : 'Output Price Per Token (USD)'
-                            table.push([usdLabel, pricingUSD.completion])
+                        const pricingUSD = modelInfo?.pricing_usd
+                        if (pricingUSD) {
+                            if (!isImageService && pricingUSD.prompt) {
+                                table.push(['Input Price Per Token (USD)', pricingUSD.prompt])
+                            }
+                            if (pricingUSD.image) {
+                                table.push(['Price Per Image (USD)', pricingUSD.image])
+                            } else if (pricingUSD.completion) {
+                                const usdLabel = isImageService
+                                    ? 'Price Per Image (USD)'
+                                    : 'Output Price Per Token (USD)'
+                                table.push([usdLabel, pricingUSD.completion])
+                            }
                         }
                     }
 

--- a/src.ts/example/inference-server.ts
+++ b/src.ts/example/inference-server.ts
@@ -63,7 +63,8 @@ export async function runInferenceServer(options: InferenceServerOptions) {
 
         // Respect a caller-specified model (multi-model providers serve many);
         // only fall back to the provider's default when the request omits one.
-        // The broker validates the model against its allowlist and bills it.
+        // The model is forwarded as-is; the provider validates it against the
+        // models it serves and bills it, rejecting an unknown id server-side.
         if (!body.model) {
             body.model = model
         }

--- a/src.ts/example/inference-server.ts
+++ b/src.ts/example/inference-server.ts
@@ -61,7 +61,12 @@ export async function runInferenceServer(options: InferenceServerOptions) {
                 : ''
         )
 
-        body.model = model
+        // Respect a caller-specified model (multi-model providers serve many);
+        // only fall back to the provider's default when the request omits one.
+        // The broker validates the model against its allowlist and bills it.
+        if (!body.model) {
+            body.model = model
+        }
         if (stream) {
             body.stream = true
         }

--- a/src.ts/sdk/inference/broker/broker.ts
+++ b/src.ts/sdk/inference/broker/broker.ts
@@ -303,20 +303,28 @@ export class InferenceBroker extends ReadOnlyInferenceBroker {
      * 2. Model information for the provider service
      *
      * @param {string} providerAddress - The address of the provider.
+     * @param {string} [model] - Optional model id to use. For multi-model
+     *   providers, pass one of the ids from `getProviderModels()` to select a
+     *   specific model; the broker validates it against its allowlist and bills
+     *   that model's price. Omit to use the provider's on-chain default model
+     *   (the only model for single-model providers). Backward-compatible.
      *
-     * @returns { endpoint, model } - Object containing endpoint and model.
+     * @returns { endpoint, model } - Object containing endpoint and the
+     *   resolved model (the requested model when provided, else the default).
      *
      * @throws An error if errors occur during the processing of the request.
      */
     public getServiceMetadata = async (
-        providerAddress: string
+        providerAddress: string,
+        model?: string
     ): Promise<{
         endpoint: string
         model: string
     }> => {
         try {
             return await this.requestProcessor.getServiceMetadata(
-                providerAddress
+                providerAddress,
+                model
             )
         } catch (error) {
             throwFormattedError(error)

--- a/src.ts/sdk/inference/broker/broker.ts
+++ b/src.ts/sdk/inference/broker/broker.ts
@@ -305,9 +305,11 @@ export class InferenceBroker extends ReadOnlyInferenceBroker {
      * @param {string} providerAddress - The address of the provider.
      * @param {string} [model] - Optional model id to use. For multi-model
      *   providers, pass one of the ids from `getProviderModels()` to select a
-     *   specific model; the broker validates it against its allowlist and bills
-     *   that model's price. Omit to use the provider's on-chain default model
-     *   (the only model for single-model providers). Backward-compatible.
+     *   specific model. The id is forwarded as-is (not validated locally); the
+     *   provider validates it against the models it serves and bills that
+     *   model's price, rejecting an unknown id server-side. Omit to use the
+     *   provider's on-chain default model (the only model for single-model
+     *   providers). Backward-compatible.
      *
      * @returns { endpoint, model } - Object containing endpoint and the
      *   resolved model (the requested model when provided, else the default).

--- a/src.ts/sdk/inference/broker/read-only-broker.ts
+++ b/src.ts/sdk/inference/broker/read-only-broker.ts
@@ -4,11 +4,11 @@ import { JsonRpcProvider as JsonRpcProviderClass } from 'ethers'
 import type { ServiceStructOutput } from '../contract'
 import { ReadOnlyInferenceServingContract } from '../contract'
 import { ReadOnlyModelProcessor } from './read-only-model'
-import type { ServiceWithDetail } from './read-only-model'
+import type { ServiceWithDetail, ProviderModels } from './read-only-model'
 import { CONTRACT_ADDRESSES, TESTNET_CHAIN_ID, MAINNET_CHAIN_ID, HARDHAT_CHAIN_ID, isDevMode } from '../../constants'
 
 // Re-export types for convenience
-export type { ServiceWithDetail } from './read-only-model'
+export type { ServiceWithDetail, ProviderModels } from './read-only-model'
 
 /**
  * Read-only inference broker with operations that don't require authentication
@@ -81,6 +81,30 @@ export class ReadOnlyInferenceBroker {
         includeUnacknowledged: boolean = false
     ): Promise<ServiceWithDetail[]> {
         return this.modelProcessor.listServiceWithDetail(offset, limit, includeUnacknowledged)
+    }
+
+    /**
+     * Fetch the models a specific provider serves, live from its public
+     * /v1/models endpoint. Works for both single-model and multi-model
+     * providers; no authentication required.
+     *
+     * @param {string} providerAddress - The provider's on-chain address.
+     * @returns {Promise<ProviderModels>} The provider's model catalog plus its
+     *   multi-model flag and on-chain default model.
+     * @throws An error if the on-chain read or the /v1/models fetch fails.
+     *
+     * @example
+     * ```typescript
+     * const { multiModel, models } = await broker.getProviderModels(addr);
+     * if (multiModel) {
+     *   models.forEach(m => console.log(m.id, m.canonical_id));
+     * }
+     * ```
+     */
+    public async getProviderModels(
+        providerAddress: string
+    ): Promise<ProviderModels> {
+        return this.modelProcessor.getProviderModels(providerAddress)
     }
 }
 

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -478,6 +478,7 @@ export class ReadOnlyModelProcessor {
                     const modelInfo = providerModels.find(
                         (m) => m.id === service.model
                     )
+                    const multi = parseMultiModelInfo(service.additionalInfo)
                     return {
                         provider: service.provider,
                         serviceType: service.serviceType,
@@ -506,11 +507,8 @@ export class ReadOnlyModelProcessor {
                         cacheTokenBilling:
                             parseCacheTokenBilling(service.additionalInfo) ??
                             parseCacheTokenBillingFromModelInfo(modelInfo),
-                        multiModel: parseMultiModelInfo(service.additionalInfo)
-                            .multiModel,
-                        priceDenomination: parseMultiModelInfo(
-                            service.additionalInfo
-                        ).priceDenomination,
+                        multiModel: multi.multiModel,
+                        priceDenomination: multi.priceDenomination,
                         models:
                             providerModels.length > 0
                                 ? providerModels
@@ -535,9 +533,15 @@ export class ReadOnlyModelProcessor {
      * with multiModel=false. The on-chain default model (used when a request
      * omits `model`) is returned as `defaultModel`.
      *
+     * Unlike {@link listServiceWithDetail} (which degrades silently when a
+     * provider is unreachable, since it lists many), this REJECTS if the
+     * provider is unreachable or returns an unexpected response shape — you
+     * asked about one specific provider, so an empty result must mean "serves
+     * no models", never "the fetch quietly failed". Callers should try/catch.
+     *
      * @param providerAddress - The provider's on-chain address.
      * @returns The provider's model catalog plus its multi-model flag.
-     * @throws If the on-chain service read or the /v1/models fetch fails.
+     * @throws If the on-chain read, the /v1/models fetch, or the response shape fails.
      */
     async getProviderModels(providerAddress: string): Promise<ProviderModels> {
         try {
@@ -546,10 +550,22 @@ export class ReadOnlyModelProcessor {
             const base = service.url.replace(/\/+$/, '')
             const resp = await axios.get(`${base}/v1/models`, {
                 timeout: 10000,
+                // Bound the response so a hostile/broken provider can't OOM the
+                // client by streaming a huge body within the timeout window.
+                maxContentLength: 5_000_000,
+                maxBodyLength: 5_000_000,
             })
-            const models: ProviderModelInfo[] = Array.isArray(resp.data?.data)
-                ? resp.data.data
-                : []
+            // A valid /v1/models response is { object: "list", data: [...] }.
+            // Treat a non-array `data` as a schema violation (throw) rather than
+            // coercing to [], so "no models" stays distinguishable from a garbage
+            // 200 (e.g. an HTML error page or { error: ... }).
+            const data = resp.data?.data
+            if (!Array.isArray(data)) {
+                throw new Error(
+                    'provider /v1/models returned an unexpected response shape (missing "data" array)'
+                )
+            }
+            const models: ProviderModelInfo[] = data
             return {
                 provider: service.provider,
                 url: service.url,

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -53,6 +53,12 @@ export interface ServiceHealthMetric {
 export interface ProviderModelInfo {
     id: string
     provider?: string
+    /**
+     * Router-owned canonical model id this model maps to (bare lowercase, e.g.
+     * "glm-5.1"). Emitted per-model by multi-model providers so a catalog can
+     * group endpoints under a canonical model. Optional.
+     */
+    canonical_id?: string
     object?: string
     created?: number
     owned_by?: string
@@ -82,6 +88,8 @@ export interface ProviderModelInfo {
         completion?: string
         /** Price per generated image (text-to-image services) */
         image?: string
+        /** Price per effective output second (video-generation services) */
+        video?: string
         /** Tiered pricing tiers based on input token count */
         tiered_pricing?: Array<{
             max_input_tokens: number
@@ -104,6 +112,8 @@ export interface ProviderModelInfo {
         completion?: string
         /** USD price per generated image (image services) */
         image?: string
+        /** USD price per effective output second (video-generation services) */
+        video?: string
         /** Tiered pricing tiers based on input token count */
         tiered_pricing?: Array<{
             max_input_tokens: number
@@ -249,6 +259,66 @@ export function parseCacheTokenBillingFromModelInfo(
 }
 
 /**
+ * Multi-model serving info parsed from service additionalInfo.
+ *
+ * A centralized provider that serves N models advertises `MultiModel: true`
+ * (and its price denomination) on-chain. The full per-model catalog is NOT
+ * on-chain — fetch it from the provider's /v1/models endpoint via
+ * {@link ReadOnlyModelProcessor.getProviderModels}.
+ */
+export interface MultiModelInfo {
+    /** True if this provider serves multiple models behind one address. */
+    multiModel: boolean
+    /** Price denomination advertised on-chain ("USD" | "NATIVE"); undefined when absent. */
+    priceDenomination?: string
+}
+
+/**
+ * Parse multi-model serving info from a service's additionalInfo JSON string.
+ * Returns { multiModel: false } when absent or the JSON is invalid (so a
+ * single-model / legacy provider degrades cleanly).
+ */
+export function parseMultiModelInfo(additionalInfo: string): MultiModelInfo {
+    try {
+        const parsed = JSON.parse(additionalInfo)
+        if (parsed?.MultiModel === true) {
+            return {
+                multiModel: true,
+                priceDenomination:
+                    typeof parsed.priceDenomination === 'string'
+                        ? parsed.priceDenomination
+                        : undefined,
+            }
+        }
+    } catch {
+        // additionalInfo not valid JSON / no MultiModel flag
+    }
+    return { multiModel: false }
+}
+
+/**
+ * A provider's served-model catalog, fetched live from its public /v1/models
+ * endpoint. Authoritative per-provider view (per-model pricing, canonical id,
+ * type) for both single-model and multi-model providers.
+ */
+export interface ProviderModels {
+    provider: string
+    /** Provider base URL (the on-chain service.url). */
+    url: string
+    /** True if the provider advertises multi-model serving on-chain. */
+    multiModel: boolean
+    /** Price denomination advertised on-chain ("USD" | "NATIVE"), if any. */
+    priceDenomination?: string
+    /**
+     * The on-chain default model — billed/forwarded when a request omits `model`.
+     * For multi-model providers, callers should pick one of `models[].id` instead.
+     */
+    defaultModel: string
+    /** Models served by this provider (exactly one for single-model providers). */
+    models: ProviderModelInfo[]
+}
+
+/**
  * Service information with optional health metrics and provider model info
  */
 export interface ServiceWithDetail {
@@ -272,6 +342,17 @@ export interface ServiceWithDetail {
     modelInfo?: ProviderModelInfo
     tieredPricing?: TieredPricingInfo
     cacheTokenBilling?: CacheTokenBillingInfo
+    /** True if this provider serves multiple models (from on-chain additionalInfo). */
+    multiModel?: boolean
+    /** Price denomination advertised on-chain ("USD" | "NATIVE"), if any. */
+    priceDenomination?: string
+    /**
+     * All models this provider serves, when known from the status API. For a
+     * multi-model provider this has the full catalog; for a single-model
+     * provider it is the one model (or omitted if the status API had none).
+     * Authoritative live data is available via getProviderModels().
+     */
+    models?: ProviderModelInfo[]
 }
 
 /**
@@ -425,11 +506,58 @@ export class ReadOnlyModelProcessor {
                         cacheTokenBilling:
                             parseCacheTokenBilling(service.additionalInfo) ??
                             parseCacheTokenBillingFromModelInfo(modelInfo),
+                        multiModel: parseMultiModelInfo(service.additionalInfo)
+                            .multiModel,
+                        priceDenomination: parseMultiModelInfo(
+                            service.additionalInfo
+                        ).priceDenomination,
+                        models:
+                            providerModels.length > 0
+                                ? providerModels
+                                : undefined,
                     }
                 }
             )
 
             return servicesWithDetail
+        } catch (error) {
+            throwFormattedError(error)
+        }
+    }
+
+    /**
+     * Fetch the models a single provider serves, live from its public
+     * /v1/models endpoint (no authentication required). Authoritative
+     * per-provider view including per-model pricing, canonical id, and type —
+     * works for both single-model and multi-model providers.
+     *
+     * Backward-compatible: a single-model provider returns exactly one model
+     * with multiModel=false. The on-chain default model (used when a request
+     * omits `model`) is returned as `defaultModel`.
+     *
+     * @param providerAddress - The provider's on-chain address.
+     * @returns The provider's model catalog plus its multi-model flag.
+     * @throws If the on-chain service read or the /v1/models fetch fails.
+     */
+    async getProviderModels(providerAddress: string): Promise<ProviderModels> {
+        try {
+            const service = await this.contract.getService(providerAddress)
+            const meta = parseMultiModelInfo(service.additionalInfo)
+            const base = service.url.replace(/\/+$/, '')
+            const resp = await axios.get(`${base}/v1/models`, {
+                timeout: 10000,
+            })
+            const models: ProviderModelInfo[] = Array.isArray(resp.data?.data)
+                ? resp.data.data
+                : []
+            return {
+                provider: service.provider,
+                url: service.url,
+                multiModel: meta.multiModel,
+                priceDenomination: meta.priceDenomination,
+                defaultModel: service.model,
+                models,
+            }
         } catch (error) {
             throwFormattedError(error)
         }

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -16,6 +16,53 @@ export type Verifiability =
 
 export type HealthStatus = 'healthy' | 'warning' | 'critical' | 'unknown'
 
+/**
+ * Attach per-model health (from the status API `/health`) onto each served
+ * model, in place. The status API reports health per (provider, model), so this
+ * preserves multi-model granularity that a provider-only map would lose.
+ *
+ * Matching is, in order:
+ *   1. exact model id  (`metric.model === model.id`)
+ *   2. canonical id    (`metric.model === model.canonical_id`)
+ *   3. single-model fallback — if this provider advertises exactly one model and
+ *      the status API has exactly one health entry for it, they must describe the
+ *      same model, so attach it even when the ids drift (observed in practice:
+ *      `/health` and a provider's `/v1/models` can report different ids for the
+ *      same single-model provider).
+ *
+ * Models with no resolvable metric are left untouched (healthMetrics undefined).
+ */
+function attachModelHealth(
+    provider: string,
+    models: ProviderModelInfo[],
+    metrics: ServiceHealthMetric[]
+): void {
+    const providerKey = provider.toLowerCase()
+    const forProvider = metrics.filter(
+        (m) => m.provider && m.provider.toLowerCase() === providerKey && m.model
+    )
+    if (forProvider.length === 0) return
+
+    const byModel = new Map<string, ServiceHealthMetric>()
+    for (const m of forProvider) {
+        byModel.set(m.model, m)
+    }
+
+    for (const model of models) {
+        let health =
+            byModel.get(model.id) ??
+            (model.canonical_id
+                ? byModel.get(model.canonical_id)
+                : undefined)
+        if (!health && models.length === 1 && forProvider.length === 1) {
+            health = forProvider[0]
+        }
+        if (health) {
+            model.healthMetrics = health
+        }
+    }
+}
+
 export interface ServiceHealthMetric {
     serviceType: string
     model: string
@@ -131,6 +178,18 @@ export interface ProviderModelInfo {
     tee_attested?: boolean
     tee_type?: string
     tee_verifier?: string
+    /**
+     * Per-model health/uptime metrics merged from the status API `/health`
+     * endpoint (NOT part of the raw /v1/models payload). Populated by
+     * {@link ReadOnlyModelProcessor.getProviderModels} and
+     * {@link ReadOnlyModelProcessor.listServiceWithDetail} when the status API
+     * has a metric for this exact (provider, model) pair; omitted otherwise.
+     *
+     * This is per-(provider, model), so multi-model providers expose distinct
+     * uptime/latency per served model — unlike the provider-level
+     * {@link ServiceWithDetail.healthMetrics}, which collapses to one entry.
+     */
+    healthMetrics?: ServiceHealthMetric
 }
 
 /**
@@ -467,6 +526,14 @@ export class ReadOnlyModelProcessor {
                 providerModelsMap.set(key, list)
             }
 
+            // Attach per-(provider, model) health so consumers (e.g. the router)
+            // get per-model uptime/latency even for multi-model providers — the
+            // provider-level `healthMetrics` below collapses to a single entry and
+            // would lose that granularity.
+            for (const [providerKey, providerModels] of providerModelsMap) {
+                attachModelHealth(providerKey, providerModels, healthMetrics)
+            }
+
             // Merge health metrics and model info with services
             // Note: Explicitly construct clean objects to avoid numeric indices from ethers Result type
             const servicesWithDetail: ServiceWithDetail[] = services.map(
@@ -548,13 +615,31 @@ export class ReadOnlyModelProcessor {
             const service = await this.contract.getService(providerAddress)
             const meta = parseMultiModelInfo(service.additionalInfo)
             const base = service.url.replace(/\/+$/, '')
-            const resp = await axios.get(`${base}/v1/models`, {
-                timeout: 10000,
-                // Bound the response so a hostile/broken provider can't OOM the
-                // client by streaming a huge body within the timeout window.
-                maxContentLength: 5_000_000,
-                maxBodyLength: 5_000_000,
-            })
+            const chainId = await this.contract.getChainId()
+            const statusApiEndpoint = this.getStatusApiEndpoint(chainId)
+
+            // The provider's own /v1/models is authoritative (and REQUIRED — its
+            // failure rejects). The status API /health is best-effort metrics
+            // enrichment: a .catch keeps a down/slow status API from failing the
+            // whole call, since the model catalog is still valid without it.
+            let healthMetrics: ServiceHealthMetric[] = []
+            const [resp] = await Promise.all([
+                axios.get(`${base}/v1/models`, {
+                    timeout: 10000,
+                    // Bound the response so a hostile/broken provider can't OOM
+                    // the client by streaming a huge body within the timeout.
+                    maxContentLength: 5_000_000,
+                    maxBodyLength: 5_000_000,
+                }),
+                axios
+                    .get(`${statusApiEndpoint}/health`, { timeout: 10000 })
+                    .then((r) => {
+                        healthMetrics = Array.isArray(r.data?.services)
+                            ? r.data.services
+                            : []
+                    })
+                    .catch(() => {}),
+            ])
             // A valid /v1/models response is { object: "list", data: [...] }.
             // Treat a non-array `data` as a schema violation (throw) rather than
             // coercing to [], so "no models" stays distinguishable from a garbage
@@ -566,6 +651,11 @@ export class ReadOnlyModelProcessor {
                 )
             }
             const models: ProviderModelInfo[] = data
+
+            // Attach per-(provider, model) health from the status API so each
+            // served model carries its own uptime/latency (multi-model granularity).
+            attachModelHealth(service.provider, models, healthMetrics)
+
             return {
                 provider: service.provider,
                 url: service.url,

--- a/src.ts/sdk/inference/broker/request.ts
+++ b/src.ts/sdk/inference/broker/request.ts
@@ -60,14 +60,20 @@ export class RequestProcessor extends ZGServingUserBrokerBase {
         this.automata = new Automata()
     }
 
-    async getServiceMetadata(providerAddress: string): Promise<{
+    async getServiceMetadata(
+        providerAddress: string,
+        model?: string
+    ): Promise<{
         endpoint: string
         model: string
     }> {
         const service = await this.getService(providerAddress)
         return {
             endpoint: `${service.url}/v1/proxy`,
-            model: service.model,
+            // Requested model (multi-model selection) wins; otherwise the
+            // on-chain default. The broker validates the model against its
+            // allowlist and bills the resolved model's price.
+            model: model ?? service.model,
         }
     }
 

--- a/src.ts/sdk/inference/broker/request.ts
+++ b/src.ts/sdk/inference/broker/request.ts
@@ -71,8 +71,9 @@ export class RequestProcessor extends ZGServingUserBrokerBase {
         return {
             endpoint: `${service.url}/v1/proxy`,
             // Requested model (multi-model selection) wins; otherwise the
-            // on-chain default. The broker validates the model against its
-            // allowlist and bills the resolved model's price.
+            // on-chain default. This SDK does NOT validate the id locally — the
+            // provider validates the resolved model against the models it serves
+            // and bills that model's price; an unknown id fails provider-side.
             model: model ?? service.model,
         }
     }

--- a/src.ts/sdk/inference/index.ts
+++ b/src.ts/sdk/inference/index.ts
@@ -23,6 +23,8 @@ export type {
     CacheTokenBillingInfo,
     MultiModelInfo,
     ProviderModels,
+    ServiceHealthMetric,
+    HealthStatus,
 } from './broker'
 export {
     parseTieredPricing,

--- a/src.ts/sdk/inference/index.ts
+++ b/src.ts/sdk/inference/index.ts
@@ -21,5 +21,11 @@ export type {
     PricingTier,
     TieredPricingInfo,
     CacheTokenBillingInfo,
+    MultiModelInfo,
+    ProviderModels,
 } from './broker'
-export { parseTieredPricing, parseCacheTokenBilling } from './broker'
+export {
+    parseTieredPricing,
+    parseCacheTokenBilling,
+    parseMultiModelInfo,
+} from './broker'


### PR DESCRIPTION
Adapts the client SDK + CLI for the broker's **multi-model serving** (one provider → N models, each with its own pricing). Consumes the upstream broker work in `0g-serving-broker#511`. Branched off latest `main`.

Backward-compatible: every addition is optional; single-model providers and existing callers/imports are unchanged. No public method signature is broken (only an optional trailing param added).

## What

### 1. Distinguish multi-model providers (zero network)
- `parseMultiModelInfo(additionalInfo)` reads the on-chain `MultiModel` flag + `priceDenomination` (authoritative, no HTTP).
- `inference list-providers` now marks a multi-model provider (denomination + default model + a `get-models` hint) instead of just printing one `model`.
- `ServiceWithDetail` gains `multiModel` / `priceDenomination` / `models`.

### 2. Get a provider's specific models
- `getProviderModels(providerAddress)` fetches the catalog **live** from the provider's public `GET ${url}/v1/models` (no auth). Returns `{ multiModel, priceDenomination, defaultModel, models[] }`. On `ReadOnlyInferenceBroker`, inherited by the authenticated `InferenceBroker`.
- Fails loud (throws) on an unreachable provider or a non-array response shape — so "serves no models" stays distinguishable from a garbage `200`; response size-capped to guard against a hostile body.
- New CLI: `inference get-models --provider <addr>` (id / canonical / type / pricing).
- `ProviderModelInfo` aligned with the broker's `/v1/models` fields: `canonical_id`, `pricing.video`, `pricing_usd.video`.

### 3. Select a model when calling a multi-model provider
- `getServiceMetadata(providerAddress, model?)` — optional model override; returns the requested model when given, else the on-chain default. The broker validates it against its allowlist and bills that model's price.
- The example server no longer force-overwrites `body.model` — it respects a caller-specified model and only default-fills when absent.
- README gains a "Multi-model providers" section (discover → select → call).

## Verification
`tsc -b` (commonjs + cli + types) clean; `eslint` 0 errors. Reviewed (correctness / security / API-design / silent-failure); all findings resolved.

## Depends on
Upstream broker `0g-serving-broker#511` (advertises `MultiModel` on-chain + serves the per-model catalog at `/v1/models`). Until a provider runs that, `multiModel` is simply `false` everywhere and behavior is identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
