### PR TITLE
feat(inference): per-second billing support for speech-to-text + web UI maintenance notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0gfoundation/0g-compute-ts-sdk",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {

--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -165,8 +165,10 @@ export default function inference(program: Command) {
                     const isImageService =
                         service.serviceType === 'text-to-image' ||
                         service.serviceType === 'image-editing'
+                    const isSpeechService =
+                        service.serviceType === 'speech-to-text'
 
-                    if (tiered && !isImageService) {
+                    if (tiered && !isImageService && !isSpeechService) {
                         // Display tiered pricing with optional cache hit prices
                         pushTieredPricingRows(
                             table,
@@ -175,6 +177,16 @@ export default function inference(program: Command) {
                             tiered,
                             cacheBilling
                         )
+                    } else if (isSpeechService) {
+                        // Speech-to-text is billed per second of audio against inputPrice
+                        table.push([
+                            'Price Per Second (0G)',
+                            service.inputPrice
+                                ? neuronToA0gi(
+                                    BigInt(service.inputPrice)
+                                ).toFixed(18)
+                                : 'N/A',
+                        ])
                     } else {
                         // Original flat pricing display
                         if (!isImageService) {
@@ -295,8 +307,10 @@ export default function inference(program: Command) {
                     const isImageService =
                         service.serviceType === 'text-to-image' ||
                         service.serviceType === 'image-editing'
+                    const isSpeechService =
+                        service.serviceType === 'speech-to-text'
 
-                    if (service.tieredPricing && !isImageService) {
+                    if (service.tieredPricing && !isImageService && !isSpeechService) {
                         pushTieredPricingRows(
                             table,
                             BigInt(service.inputPrice),
@@ -304,6 +318,16 @@ export default function inference(program: Command) {
                             service.tieredPricing,
                             service.cacheTokenBilling
                         )
+                    } else if (isSpeechService) {
+                        // Speech-to-text is billed per second of audio against inputPrice
+                        table.push([
+                            'Price Per Second (0G)',
+                            service.inputPrice
+                                ? neuronToA0gi(
+                                    BigInt(service.inputPrice)
+                                ).toFixed(18)
+                                : 'N/A',
+                        ])
                     } else {
                         if (!isImageService) {
                             table.push([

--- a/src.ts/cli/web-ui-embedded.ts
+++ b/src.ts/cli/web-ui-embedded.ts
@@ -40,6 +40,15 @@ export async function startEmbeddedWebUI(
     port = 3090,
     host = 'localhost'
 ): Promise<void> {
+    console.log(
+        '✨ A new and improved web experience is now available at:'
+    )
+    console.log('   👉 https://pc.0g.ai/sdk')
+    console.log(
+        '   This embedded web UI is in maintenance mode and will not receive new features.'
+    )
+    console.log()
+
     const packageRoot = getPackageRoot()
     console.log(`📦 Package root: ${packageRoot}`)
 

--- a/src.ts/sdk/inference/broker/broker.ts
+++ b/src.ts/sdk/inference/broker/broker.ts
@@ -452,8 +452,11 @@ export class InferenceBroker extends ReadOnlyInferenceBroker {
      * in the `ZG-Res-Key` HTTP response header. Extract this header from the provider's response and pass
      * it here for signature verification. For providers that don't include this header, fall back to using
      * the completion ID. Example: `const chatID = response.headers.get('ZG-Res-Key') || completion.id`
-     * @param {string} content - Usage data from the response. For chatbot/speech-to-text: JSON string with
-     * token usage; For text-to-image: can be empty. This is used to calculate and cache estimated fees.
+     * @param {string} content - Usage data from the response. For chatbot: JSON string with token usage;
+     * For speech-to-text: the usage JSON from the response, either duration-billed
+     * (`{"type":"duration","seconds":N}`, billed per second against inputPrice) or token-billed
+     * (`{"type":"tokens","input_tokens":N,"output_tokens":N}`); For text-to-image: can be empty.
+     * This is used to calculate and cache estimated fees.
      *
      * @returns A boolean value. True indicates the returned content is valid, otherwise it is invalid.
      * null if no chatID provided (verification skipped).

--- a/src.ts/sdk/inference/broker/response.ts
+++ b/src.ts/sdk/inference/broker/response.ts
@@ -25,7 +25,7 @@ export class ResponseProcessor extends ZGServingUserBrokerBase {
     async processResponse(
         providerAddress: string,
         chatID?: string,
-        content?: string // For chatbot/speech-to-text: usage JSON string with input_tokens/output_tokens; For text-to-image: empty/undefined
+        content?: string // For chatbot: usage JSON with input_tokens/output_tokens; For speech-to-text: usage JSON, duration-billed ({"type":"duration","seconds":N}) or token-billed ({"type":"tokens",...}); For text-to-image: empty/undefined
     ): Promise<boolean | null> {
         try {
             const extractor = await this.getExtractor(providerAddress)

--- a/src.ts/sdk/inference/extractor/__tests__/speech-to-text.test.ts
+++ b/src.ts/sdk/inference/extractor/__tests__/speech-to-text.test.ts
@@ -1,0 +1,114 @@
+// Unit tests for the speech-to-text usage extractor's dual billing modes.
+// The dispatch rules must stay in sync with the broker's settlement logic
+// (isDurationUsage / billableSeconds in 0g-serving-broker): the cached fee
+// estimate the SDK computes drives auto top-up, and a divergence between the
+// two re-introduces the zero-fee bug class the broker fixed in PR #523.
+
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { SpeechToText } from '../speech-to-text'
+import type { ServiceStructOutput } from '../../contract'
+
+const svcInfo = {} as ServiceStructOutput
+
+const extractor = new SpeechToText(svcInfo)
+
+describe('SpeechToText extractor', () => {
+    describe('duration-billed usage (whisper family)', () => {
+        it('uses seconds as input count', async () => {
+            const usage = JSON.stringify({ type: 'duration', seconds: 207 })
+            expect(await extractor.getInputCount(usage)).to.equal(207)
+            expect(await extractor.getOutputCount(usage)).to.equal(0)
+        })
+
+        it('rounds fractional seconds to the nearest second', async () => {
+            expect(
+                await extractor.getInputCount(
+                    JSON.stringify({ type: 'duration', seconds: 207.5 })
+                )
+            ).to.equal(208)
+            expect(
+                await extractor.getInputCount(
+                    JSON.stringify({ type: 'duration', seconds: 207.4 })
+                )
+            ).to.equal(207)
+        })
+
+        it('floors sub-second positive durations to 1 second', async () => {
+            expect(
+                await extractor.getInputCount(
+                    JSON.stringify({ type: 'duration', seconds: 0.4 })
+                )
+            ).to.equal(1)
+        })
+
+        it('returns 0 for zero or negative seconds', async () => {
+            expect(
+                await extractor.getInputCount(
+                    JSON.stringify({ type: 'duration', seconds: 0 })
+                )
+            ).to.equal(0)
+            expect(
+                await extractor.getInputCount(
+                    JSON.stringify({ type: 'duration', seconds: -5 })
+                )
+            ).to.equal(0)
+        })
+
+        it('routes to duration when seconds is populated without a type field', async () => {
+            const usage = JSON.stringify({ seconds: 42 })
+            expect(await extractor.getInputCount(usage)).to.equal(42)
+            expect(await extractor.getOutputCount(usage)).to.equal(0)
+        })
+    })
+
+    describe('token-billed usage (gpt-4o-transcribe family)', () => {
+        it('uses input_tokens and output_tokens', async () => {
+            const usage = JSON.stringify({
+                type: 'tokens',
+                input_tokens: 120,
+                output_tokens: 30,
+            })
+            expect(await extractor.getInputCount(usage)).to.equal(120)
+            expect(await extractor.getOutputCount(usage)).to.equal(30)
+        })
+
+        it('stays on the tokens path even with a stray seconds field', async () => {
+            const usage = JSON.stringify({
+                type: 'tokens',
+                input_tokens: 120,
+                output_tokens: 0,
+                seconds: 99,
+            })
+            expect(await extractor.getInputCount(usage)).to.equal(120)
+            expect(await extractor.getOutputCount(usage)).to.equal(0)
+        })
+
+        it('accepts string-encoded token counts', async () => {
+            const usage = JSON.stringify({
+                type: 'tokens',
+                input_tokens: '120',
+                output_tokens: '30',
+            })
+            expect(await extractor.getInputCount(usage)).to.equal(120)
+            expect(await extractor.getOutputCount(usage)).to.equal(30)
+        })
+    })
+
+    describe('malformed usage', () => {
+        it('returns 0 for empty content', async () => {
+            expect(await extractor.getInputCount('')).to.equal(0)
+            expect(await extractor.getOutputCount('')).to.equal(0)
+        })
+
+        it('returns 0 for invalid JSON', async () => {
+            expect(await extractor.getInputCount('not json')).to.equal(0)
+            expect(await extractor.getOutputCount('not json')).to.equal(0)
+        })
+
+        it('returns 0 for an empty usage object', async () => {
+            expect(await extractor.getInputCount('{}')).to.equal(0)
+            expect(await extractor.getOutputCount('{}')).to.equal(0)
+        })
+    })
+})

--- a/src.ts/sdk/inference/extractor/speech-to-text.ts
+++ b/src.ts/sdk/inference/extractor/speech-to-text.ts
@@ -1,6 +1,61 @@
 import type { ServiceStructOutput } from '../contract'
 import { Extractor } from './extractor'
 
+/**
+ * Speech-to-text usage shape returned by providers. Two billing modes exist,
+ * mirroring the broker's settlement logic:
+ *
+ * - duration (whisper family): `{"type":"duration","seconds":N}`. The service
+ *   inputPrice is interpreted as price-per-second; outputPrice is unused.
+ * - tokens (gpt-4o-transcribe family): `{"type":"tokens","input_tokens":N,"output_tokens":N}`.
+ *   Standard per-token pricing applies.
+ *
+ * Dispatch rule (must stay in sync with the broker's isDurationUsage): trust
+ * an explicit `type` discriminator when present; otherwise treat usage with a
+ * positive `seconds` as duration-billed.
+ */
+interface SpeechToTextUsage {
+    type?: string
+    seconds?: number
+    input_tokens?: number | string
+    output_tokens?: number | string
+}
+
+function parseUsage(content: string): SpeechToTextUsage | null {
+    if (!content) {
+        return null
+    }
+    try {
+        const usage = JSON.parse(content)
+        return usage && typeof usage === 'object' ? usage : null
+    } catch {
+        return null
+    }
+}
+
+function toCount(value: number | string | undefined): number {
+    const num = typeof value === 'string' ? parseInt(value, 10) : value
+    return typeof num === 'number' && !isNaN(num) && num > 0 ? num : 0
+}
+
+function isDurationUsage(usage: SpeechToTextUsage): boolean {
+    const seconds = typeof usage.seconds === 'number' ? usage.seconds : 0
+    return usage.type === 'duration' || (usage.type !== 'tokens' && seconds > 0)
+}
+
+/**
+ * Billable seconds for duration-mode usage: round to the nearest second with
+ * a 1-second floor for any positive duration, matching the broker's
+ * billableSeconds() so the cached fee estimate agrees with settlement.
+ */
+function billableSeconds(usage: SpeechToTextUsage): number {
+    const seconds = typeof usage.seconds === 'number' ? usage.seconds : 0
+    if (seconds <= 0) {
+        return 0
+    }
+    return Math.max(Math.round(seconds), 1)
+}
+
 export class SpeechToText extends Extractor {
     svcInfo: ServiceStructOutput
 
@@ -13,33 +68,27 @@ export class SpeechToText extends Extractor {
         return Promise.resolve(this.svcInfo)
     }
 
-    async getInputCount(_content: string): Promise<number> {
-        // For speech-to-text, inputCount should always be 0
-        // as the actual token counts come from the usage field
-        return 0
+    async getInputCount(content: string): Promise<number> {
+        const usage = parseUsage(content)
+        if (!usage) {
+            return 0
+        }
+        if (isDurationUsage(usage)) {
+            // Duration billing: inputPrice is price-per-second
+            return billableSeconds(usage)
+        }
+        return toCount(usage.input_tokens)
     }
 
     async getOutputCount(content: string): Promise<number> {
-        // For speech-to-text, parse the usage field to get token counts
-        // content should be a JSON string with usage field containing input_tokens and output_tokens
-        if (!content) {
+        const usage = parseUsage(content)
+        if (!usage) {
             return 0
         }
-
-        try {
-            const usage = JSON.parse(content)
-            // We only care about output_tokens from the usage object
-            if (usage && usage.output_tokens !== undefined) {
-                const tokens =
-                    typeof usage.output_tokens === 'string'
-                        ? parseInt(usage.output_tokens, 10)
-                        : usage.output_tokens
-                return typeof tokens === 'number' && !isNaN(tokens) ? tokens : 0
-            }
-            return 0
-        } catch {
-            // If parsing fails, return 0
+        if (isDurationUsage(usage)) {
+            // Duration billing has no generation-side cost
             return 0
         }
+        return toCount(usage.output_tokens)
     }
 }

--- a/web-ui/src/app/inference/components/ModelCard.tsx
+++ b/web-ui/src/app/inference/components/ModelCard.tsx
@@ -27,24 +27,38 @@ const SERVICE_TYPE_CONFIG: Record<string, { label: string; icon: React.ElementTy
     'speech-to-text': { label: 'Speech to Text', icon: Mic, color: 'bg-amber-100 text-amber-700', hoverColor: 'hover:bg-amber-100 hover:text-amber-700' },
 }
 
+function formatPrice(value: number): string {
+    // Per-second prices (speech-to-text) can be far below 0.01 0G;
+    // fall back to more decimals so they don't render as "0.00"
+    if (value > 0 && value < 0.01) {
+        return parseFloat(value.toFixed(6)).toString()
+    }
+    return value.toFixed(2)
+}
+
 function formatPriceRange(range: { min: number; max: number } | null): string | null {
     if (!range) return null
     if (range.min === range.max) {
-        return range.min.toFixed(2)
+        return formatPrice(range.min)
     }
-    return `${range.min.toFixed(2)} - ${range.max.toFixed(2)}`
+    return `${formatPrice(range.min)} - ${formatPrice(range.max)}`
 }
 
 export function ModelCard({ model, onClick }: ModelCardProps) {
     const typeConfig = SERVICE_TYPE_CONFIG[model.serviceType] || SERVICE_TYPE_CONFIG.chatbot
     const TypeIcon = typeConfig.icon
     const isImageService = model.serviceType === 'text-to-image' || model.serviceType === 'image-editing'
+    const isSpeechService = model.serviceType === 'speech-to-text'
 
     const priceDisplay = isImageService
         ? formatPriceRange(model.outputPriceRange)
         : formatPriceRange(model.inputPriceRange)
 
-    const priceUnit = isImageService ? '0G/image' : '0G/1M tokens'
+    const priceUnit = isImageService
+        ? '0G/image'
+        : isSpeechService
+          ? '0G/second'
+          : '0G/1M tokens'
 
     return (
         <Card

--- a/web-ui/src/app/inference/components/ProviderCard.tsx
+++ b/web-ui/src/app/inference/components/ProviderCard.tsx
@@ -268,6 +268,18 @@ export function ProviderCard({
                                                         0G/image
                                                     </span>
                                                 </div>
+                                            ) : isSpeechService ? (
+                                                <div className="flex items-center gap-1">
+                                                    <span className="text-muted-foreground">
+                                                        Price:
+                                                    </span>
+                                                    <span className="font-semibold text-foreground">
+                                                        {provider.inputPrice?.toFixed(
+                                                            6
+                                                        )}{' '}
+                                                        0G/second
+                                                    </span>
+                                                </div>
                                             ) : provider.tieredPricing ? (
                                                 <div className="flex items-center gap-1">
                                                     <span className="text-muted-foreground">
@@ -355,6 +367,14 @@ export function ProviderCard({
                                                     Cost per generated image:{' '}
                                                     {provider.outputPrice?.toFixed(
                                                         4
+                                                    )}{' '}
+                                                    0G
+                                                </p>
+                                            ) : isSpeechService ? (
+                                                <p>
+                                                    Cost per second of audio:{' '}
+                                                    {provider.inputPrice?.toFixed(
+                                                        6
                                                     )}{' '}
                                                     0G
                                                 </p>

--- a/web-ui/src/app/inference/utils/providerTransform.ts
+++ b/web-ui/src/app/inference/utils/providerTransform.ts
@@ -62,10 +62,12 @@ export function transformBrokerServiceToProvider(service: unknown): Provider {
 
   // Convert prices from neuron to 0G
   // For image services (text-to-image, image-editing), prices are per image, not per million tokens
+  // For speech-to-text, prices are per second of audio (duration billing), not per million tokens
   const isImageService = serviceObj.serviceType === 'text-to-image' ||
                          serviceObj.serviceType === 'image-editing' ||
                          serviceObj.serviceType?.includes('image');
-  const priceMultiplier = isImageService ? BigInt(1) : BigInt(1000000);
+  const isSpeechService = serviceObj.serviceType === 'speech-to-text';
+  const priceMultiplier = isImageService || isSpeechService ? BigInt(1) : BigInt(1000000);
   const inputPrice = serviceObj.inputPrice
     ? neuronToA0gi(serviceObj.inputPrice * priceMultiplier)
     : undefined;

--- a/web-ui/src/app/layout.tsx
+++ b/web-ui/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Providers } from "../../Providers";
 import { Navbar } from "../shared/components/layout/Navbar";
 import { Sidebar } from "../shared/components/layout/Sidebar";
 import { LayoutContent } from "../shared/components/layout/LayoutContent";
+import { DeprecationBanner } from "../shared/components/layout/DeprecationBanner";
 import { Toaster } from "@/components/ui/toaster";
 
 // Space Grotesk as primary font (similar to Regola Pro - geometric sans-serif)
@@ -46,6 +47,7 @@ export default function RootLayout({
       <body className="font-sans antialiased">
         <Providers>
           <div className="flex min-h-screen w-full flex-col bg-background">
+            <DeprecationBanner />
             <Sidebar />
             <div className="flex flex-col sm:gap-4 sm:py-4 sm:pl-14">
               <Navbar />

--- a/web-ui/src/shared/components/layout/DeprecationBanner.tsx
+++ b/web-ui/src/shared/components/layout/DeprecationBanner.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import { X, ExternalLink } from 'lucide-react'
+
+const NEW_UI_URL = 'https://pc.0g.ai/sdk'
+
+/**
+ * Deprecation notice for the CLI-embedded web UI. New features are only
+ * added to the hosted UI at pc.0g.ai/sdk.
+ * See https://github.com/0gfoundation/0g-compute-ts-sdk/issues/207
+ */
+export function DeprecationBanner() {
+    const [dismissed, setDismissed] = useState(false)
+
+    if (dismissed) {
+        return null
+    }
+
+    return (
+        <div className="flex items-center justify-center gap-2 bg-amber-100 px-4 py-2 text-sm text-amber-900">
+            <span>
+                A new and improved web experience is now available — this
+                local UI is in maintenance mode. Check it out at{' '}
+                <a
+                    href={NEW_UI_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 font-semibold underline hover:text-amber-700"
+                >
+                    pc.0g.ai/sdk
+                    <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+            </span>
+            <button
+                type="button"
+                aria-label="Dismiss deprecation notice"
+                onClick={() => setDismissed(true)}
+                className="ml-2 rounded p-0.5 hover:bg-amber-200"
+            >
+                <X className="h-4 w-4" />
+            </button>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary

Adapts the SDK/CLI/Web UI to broker PR [0g-serving-broker#523](https://github.com/0gfoundation/0g-serving-broker/pull/523), which introduced dual billing modes for speech-to-text — seconds are now the minimum pricing unit for duration-billed speech models:

- **duration** (whisper family): usage `{"type":"duration","seconds":N}`, fee = billable seconds × inputPrice (inputPrice is price-per-second; outputPrice unused)
- **tokens** (gpt-4o-transcribe family): usage `{"type":"tokens","input_tokens":N,"output_tokens":N}`, existing per-token path

Also adds the deprecation notice requested in [0g-compute-ts-sdk#207](https://github.com/0gfoundation/0g-compute-ts-sdk/issues/207#issuecomment-4405005866), pointing users of the CLI-embedded web UI to https://pc.0g.ai/sdk.

## Changes

### SDK
- `extractor/speech-to-text.ts`: mirror the broker's dispatch rules (explicit `type` discriminator wins; otherwise positive `seconds` routes to duration). Billable seconds round to the nearest second with a 1-second floor, matching the broker's `billableSeconds()` so the SDK's cached fee estimate agrees with settlement. Fixes a latent bug where the extractor only read `output_tokens` (always 0 upstream), so the fee estimate driving auto top-up was always 0.
- `broker.ts` / `response.ts`: update `processResponse` JSDoc/comments for both usage shapes.

### CLI
- `list-providers` / `list-providers-detail`: speech-to-text services display `Price Per Second (0G)`.
- `start-web`: prints a notice pointing to the new web experience.

### Web UI
- `providerTransform.ts`: speech-to-text prices are no longer scaled per-1M-tokens (displayed per second).
- `ModelCard` / `ProviderCard`: `0G/second` unit with enough decimals for small per-second values.
- New dismissible `DeprecationBanner` directing users to https://pc.0g.ai/sdk (embedded UI is in maintenance mode).

### Tests
- New `speech-to-text.test.ts` (11 cases): duration/tokens dispatch, fractional-second rounding, 1-second floor, no-type-field routing, stray-seconds-on-tokens-path, string-encoded counts, malformed usage.

## Notes

The on-chain service struct has no billing-mode discriminator yet (broker tracks this in #530), so display layers treat speech-to-text uniformly as per-second — consistent with the seconds-as-minimum-unit direction. Token-billed STT is gated off by default on the broker side until #530 lands.

## Test plan

- [x] `tsc -b` (commonjs/types/cli) passes
- [x] `npx mocha lib.commonjs/inference/extractor/__tests__` — 11 passing
- [x] `npm test` — full suite passing
- [x] web-ui `tsc --noEmit` passes
- [x] eslint: no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)