### PR TITLE
chore: release v0.9.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0gfoundation/0g-compute-ts-sdk",
-    "version": "0.8.4",
+    "version": "0.9.0-beta.0",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {


### PR DESCRIPTION
Release `0.9.0-beta.0` to npm dist-tag `@beta` (opt-in pre-release of the multi-model feature line; `@latest` stays at `0.8.4`).

- Already published to npm: `@0gfoundation/0g-compute-ts-sdk@0.9.0-beta.0` (`@beta`).
- This PR just lands the version bump in `package.json` on `main`.
- No GitHub release (pre-release / opt-in per release-tag policy).

Builds on #220 (multi-model provider support).