### PR TITLE
feat(inference): credit mode for off-chain billing providers

### DIFF
--- a/src.ts/sdk/inference/broker/base.ts
+++ b/src.ts/sdk/inference/broker/base.ts
@@ -113,10 +113,37 @@ export interface AutoFundingConfig {
     bufferMultiplier?: number
 }
 
+/**
+ * Credit mode lets a provider that bills via an off-chain USD credit service
+ * (instead of on-chain settlement) be used through this SDK. The user still
+ * authenticates with their wallet (session tokens, on-chain identity/revocation
+ * unchanged); these flags only skip the on-chain funding/acknowledgement steps
+ * that are meaningless when billing is off-chain. See the credit-billing design
+ * doc in the broker repo.
+ */
+export interface CreditModeOptions {
+    /**
+     * Skip the inline on-chain auto-funding (checkAndFund) before each request.
+     * Required for credit users — they hold no on-chain sub-account balance, so
+     * the transfer would fail with "Insufficient balance in ledger".
+     */
+    skipAutoFunding?: boolean
+    /**
+     * Skip the userAcknowledged() gate. On-chain acknowledgement is meaningless
+     * when settlement is off-chain; enabling this lets credit users transact
+     * with only a wallet + (optional) on-chain account for revocation.
+     */
+    skipAcknowledgement?: boolean
+}
+
 export abstract class ZGServingUserBrokerBase {
     protected contract: InferenceServingContract
     protected metadata: Metadata
     protected cache: Cache
+
+    // Off-chain credit billing mode. Empty (all false) by default so on-chain
+    // users are completely unaffected.
+    protected creditMode: CreditModeOptions = {}
 
     // Minimum locked balance required by provider broker proxy (1 0G in neuron).
     // Matches MinimumLockedBalance in api/inference/const/const.go.
@@ -137,6 +164,14 @@ export abstract class ZGServingUserBrokerBase {
         this.ledger = ledger
         this.metadata = metadata
         this.cache = cache
+    }
+
+    /**
+     * Enable/configure off-chain credit billing mode. Merges with existing
+     * flags. No-op for normal on-chain usage.
+     */
+    setCreditMode(options: CreditModeOptions): void {
+        this.creditMode = { ...this.creditMode, ...options }
     }
 
     protected async getService(
@@ -562,8 +597,12 @@ export abstract class ZGServingUserBrokerBase {
      * @returns Headers with Authorization
      */
     async getHeader(providerAddress: string): Promise<ServingRequestHeaders> {
-        // Check if provider is acknowledged - this is still necessary
-        if (!(await this.userAcknowledged(providerAddress))) {
+        // Check if provider is acknowledged - this is still necessary, except in
+        // credit mode where on-chain acknowledgement is not used.
+        if (
+            !this.creditMode.skipAcknowledgement &&
+            !(await this.userAcknowledged(providerAddress))
+        ) {
             throw new Error('Provider signer is not acknowledged')
         }
 

--- a/src.ts/sdk/inference/broker/broker.ts
+++ b/src.ts/sdk/inference/broker/broker.ts
@@ -21,7 +21,7 @@ import { Cache, Metadata } from '../../common/storage'
 import type { LedgerBroker } from '../../ledger'
 import { throwFormattedError } from '../../common/utils'
 import { ReadOnlyInferenceBroker } from './read-only-broker'
-import type { AutoFundingConfig } from './base'
+import type { AutoFundingConfig, CreditModeOptions } from './base'
 
 /**
  * Full-featured inference broker with authentication required
@@ -48,6 +48,19 @@ export class InferenceBroker extends ReadOnlyInferenceBroker {
         super(signer, contractAddress)
         this.signer = signer
         this.ledger = ledger
+    }
+
+    /**
+     * Configure off-chain credit billing mode for providers that settle via a
+     * centralized USD credit service instead of on-chain. Must be called after
+     * initialize(). No-op for normal on-chain providers.
+     *
+     * @example
+     * await broker.inference.initialize?.()
+     * broker.inference.setCreditMode({ skipAutoFunding: true, skipAcknowledgement: true })
+     */
+    public setCreditMode(options: CreditModeOptions): void {
+        this.requestProcessor.setCreditMode(options)
     }
 
     async initialize(): Promise<void> {

--- a/src.ts/sdk/inference/broker/request.ts
+++ b/src.ts/sdk/inference/broker/request.ts
@@ -109,7 +109,12 @@ export class RequestProcessor extends ZGServingUserBrokerBase {
             // If no background auto-funding timer is active for this provider,
             // run an inline check-and-fund to preserve backward compatibility.
             // Users who call startAutoFunding() skip this (zero extra latency).
-            if (!this.hasAutoFunding(providerAddress)) {
+            // Credit users skip it entirely: they hold no on-chain sub-account
+            // balance, so a transfer would fail; their funds live off-chain.
+            if (
+                !this.creditMode.skipAutoFunding &&
+                !this.hasAutoFunding(providerAddress)
+            ) {
                 await this.checkAndFund(providerAddress, 2)
             }
             return await this.getHeader(providerAddress)


### PR DESCRIPTION
## What

Adds `InferenceBroker.setCreditMode({ skipAutoFunding, skipAcknowledgement })` so a wallet user can use this SDK against a provider that settles via an **off-chain USD credit service** instead of on-chain.

- `skipAutoFunding` — skips the inline `checkAndFund()` on-chain transfer before each request. Credit users hold no on-chain sub-account balance, so the transfer would otherwise fail with `Insufficient balance in ledger`.
- `skipAcknowledgement` — skips the `userAcknowledged()` gate, which is meaningless when settlement is off-chain.

## Safety

- Both flags **default off** (`creditMode = {}`); the on-chain path is byte-for-byte unchanged (both gates are `!skipX && <original condition>`).
- No change to `processResponse` / settlement logic.

## Context

Part of the off-chain credit billing design (see the broker repo `docs/design/credit-billing-provider.md`). Companion changes: broker `creditbilling` package (signed-receipt client) and the new `0g-credit-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)