### PR TITLE
feat(inference): parse fractional tier price multipliers

### DIFF
--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env ts-node
 
 import type { Command } from 'commander'
-import { withBroker, withROBroker, neuronToA0gi, a0giToNeuron, initBroker } from './util'
+import {
+    withBroker,
+    withROBroker,
+    neuronToA0gi,
+    a0giToNeuron,
+    initBroker,
+} from './util'
 import { getRpcEndpoint } from './network-setup'
 import { ensurePrivateKeyConfiguration } from './private-key-setup'
 import { interactiveSelect, textInput } from './interactive-selection'
@@ -11,8 +17,18 @@ import axios from 'axios'
 import fs from 'fs'
 import { ethers } from 'ethers'
 import { formatError } from '../sdk/common/utils/error-handler'
-import { parseTieredPricing, parseCacheTokenBilling, parseMultiModelInfo } from '../sdk/inference'
-import type { TieredPricingInfo, CacheTokenBillingInfo, ProviderModelInfo, ServiceHealthMetric } from '../sdk/inference'
+import {
+    parseTieredPricing,
+    parseCacheTokenBilling,
+    parseMultiModelInfo,
+    effectiveMultiplier,
+} from '../sdk/inference'
+import type {
+    TieredPricingInfo,
+    CacheTokenBillingInfo,
+    ProviderModelInfo,
+    ServiceHealthMetric,
+} from '../sdk/inference'
 
 /**
  * Format a token count for display (e.g., 256000 -> "256k", 1000000 -> "1M")
@@ -54,18 +70,29 @@ function pushTieredPricingRows(
     tieredPricing: TieredPricingInfo,
     cacheBilling?: CacheTokenBillingInfo
 ) {
-    table.push([chalk.yellow('Tiered Pricing (0G/Token)'), chalk.yellow('Enabled')])
+    table.push([
+        chalk.yellow('Tiered Pricing (0G/Token)'),
+        chalk.yellow('Enabled'),
+    ])
     let prevLabel = '0'
     for (const tier of tieredPricing.tiers) {
-        const rangeLabel = tier.maxInputTokens === 0
-            ? `>${prevLabel}`
-            : `${prevLabel}-${formatTokenCount(tier.maxInputTokens)}`
-        const effectiveInputPrice = applyMultiplier(baseInputPrice, tier.inputMultiplier)
+        const rangeLabel =
+            tier.maxInputTokens === 0
+                ? `>${prevLabel}`
+                : `${prevLabel}-${formatTokenCount(tier.maxInputTokens)}`
+        const effectiveInputPrice = applyMultiplier(
+            baseInputPrice,
+            tier.inputMultiplier
+        )
         const inPrice = formatPrice(effectiveInputPrice)
-        const outPrice = formatPrice(applyMultiplier(baseOutputPrice, tier.outputMultiplier))
+        const outPrice = formatPrice(
+            applyMultiplier(baseOutputPrice, tier.outputMultiplier)
+        )
         let priceStr = `In: ${inPrice} / Out: ${outPrice}`
         if (cacheBilling) {
-            const cachePrice = formatPrice(effectiveInputPrice / BigInt(cacheBilling.divisor))
+            const cachePrice = formatPrice(
+                effectiveInputPrice / BigInt(cacheBilling.divisor)
+            )
             priceStr += ` / Cache: ${cachePrice}`
         }
         table.push([`  Input ${rangeLabel} tokens`, priceStr])
@@ -122,14 +149,18 @@ function formatModelPricing(m: ProviderModelInfo, useUsd: boolean): string {
         }
     }
 
-    if (base.video !== undefined) return `${fmtPrice(toDisplay(base.video))} / sec`
-    if (base.image !== undefined) return `${fmtPrice(toDisplay(base.image))} / image`
+    if (base.video !== undefined)
+        return `${fmtPrice(toDisplay(base.video))} / sec`
+    if (base.image !== undefined)
+        return `${fmtPrice(toDisplay(base.image))} / image`
 
     const inBase = toDisplay(base.prompt)
     const outBase = toDisplay(base.completion)
     if (inBase === undefined && outBase === undefined) return 'N/A'
 
-    const lines = [`in ${fmtPrice(inBase)} / out ${fmtPrice(outBase)} per token`]
+    const lines = [
+        `in ${fmtPrice(inBase)} / out ${fmtPrice(outBase)} per token`,
+    ]
 
     const cache = base.cache_token_billing ?? alt?.cache_token_billing
     if (cache && cache.divisor > 0 && inBase !== undefined) {
@@ -147,11 +178,23 @@ function formatModelPricing(m: ProviderModelInfo, useUsd: boolean): string {
                     : `${prevLabel}-${formatTokenCount(tier.max_input_tokens)}`
             const tin =
                 inBase !== undefined
-                    ? fmtPrice(inBase * tier.input_multiplier)
+                    ? fmtPrice(
+                          inBase *
+                              effectiveMultiplier(
+                                  tier.input_multiplier,
+                                  tier.input_multiplier_denominator
+                              )
+                      )
                     : '-'
             const tout =
                 outBase !== undefined
-                    ? fmtPrice(outBase * tier.output_multiplier)
+                    ? fmtPrice(
+                          outBase *
+                              effectiveMultiplier(
+                                  tier.output_multiplier,
+                                  tier.output_multiplier_denominator
+                              )
+                      )
                     : '-'
             lines.push(`  ${rangeLabel}: in ${tin} / out ${tout}`)
             if (tier.max_input_tokens !== 0) {
@@ -191,8 +234,8 @@ function formatModelHealth(health?: ServiceHealthMetric): string {
             uptime >= 85
                 ? chalk.green(pct)
                 : uptime >= 70
-                    ? chalk.yellow(pct)
-                    : chalk.red(pct)
+                ? chalk.yellow(pct)
+                : chalk.red(pct)
         )
     }
 
@@ -294,7 +337,11 @@ export default function inference(program: Command) {
                         table.push([
                             'Models',
                             chalk.green(
-                                `multi-model${multi.priceDenomination ? ` (${multi.priceDenomination})` : ''}`
+                                `multi-model${
+                                    multi.priceDenomination
+                                        ? ` (${multi.priceDenomination})`
+                                        : ''
+                                }`
                             ) +
                                 `\nRun: 0g-compute-cli inference get-models --provider ${service.provider}`,
                         ])
@@ -302,10 +349,11 @@ export default function inference(program: Command) {
                         table.push(['Model', service.model || 'N/A'])
                     }
 
-
                     // Check for tiered pricing and cache billing in additionalInfo
                     const tiered = parseTieredPricing(service.additionalInfo)
-                    const cacheBilling = parseCacheTokenBilling(service.additionalInfo)
+                    const cacheBilling = parseCacheTokenBilling(
+                        service.additionalInfo
+                    )
                     const isImageService =
                         service.serviceType === 'text-to-image' ||
                         service.serviceType === 'image-editing'
@@ -327,8 +375,8 @@ export default function inference(program: Command) {
                             'Price Per Second (0G)',
                             service.inputPrice
                                 ? neuronToA0gi(
-                                    BigInt(service.inputPrice)
-                                ).toFixed(18)
+                                      BigInt(service.inputPrice)
+                                  ).toFixed(18)
                                 : 'N/A',
                         ])
                     } else {
@@ -338,8 +386,8 @@ export default function inference(program: Command) {
                                 'Input Price Per Token (0G)',
                                 service.inputPrice
                                     ? neuronToA0gi(
-                                        BigInt(service.inputPrice)
-                                    ).toFixed(18)
+                                          BigInt(service.inputPrice)
+                                      ).toFixed(18)
                                     : 'N/A',
                             ])
                         }
@@ -352,17 +400,25 @@ export default function inference(program: Command) {
                             outputPriceLabel,
                             service.outputPrice
                                 ? neuronToA0gi(
-                                    BigInt(service.outputPrice)
-                                ).toFixed(18)
+                                      BigInt(service.outputPrice)
+                                  ).toFixed(18)
                                 : 'N/A',
                         ])
 
                         // Show cache hit price for flat pricing (non-image services)
-                        if (cacheBilling && !isImageService && service.inputPrice) {
+                        if (
+                            cacheBilling &&
+                            !isImageService &&
+                            service.inputPrice
+                        ) {
                             const cacheHitPrice = neuronToA0gi(
-                                BigInt(service.inputPrice) / BigInt(cacheBilling.divisor)
+                                BigInt(service.inputPrice) /
+                                    BigInt(cacheBilling.divisor)
                             ).toFixed(18)
-                            table.push(['Cache Hit Price Per Token (0G)', cacheHitPrice])
+                            table.push([
+                                'Cache Hit Price Per Token (0G)',
+                                cacheHitPrice,
+                            ])
                         }
                     }
                     table.push([
@@ -377,7 +433,7 @@ export default function inference(program: Command) {
     program
         .command('get-models')
         .description(
-            "Get the models a provider serves (live from its /v1/models endpoint)"
+            'Get the models a provider serves (live from its /v1/models endpoint)'
         )
         .requiredOption('--provider <address>', 'Provider address')
         .option('--rpc <url>', '0G Chain RPC endpoint')
@@ -390,7 +446,9 @@ export default function inference(program: Command) {
                 )
                 console.log(chalk.blue(`Provider:      ${result.provider}`))
                 console.log(
-                    `Multi-model:   ${result.multiModel ? chalk.green('yes') : 'no'}` +
+                    `Multi-model:   ${
+                        result.multiModel ? chalk.green('yes') : 'no'
+                    }` +
                         (result.priceDenomination
                             ? ` (${result.priceDenomination})`
                             : '')
@@ -432,9 +490,7 @@ export default function inference(program: Command) {
 
     program
         .command('list-providers-detail')
-        .description(
-            'List inference providers with health metrics'
-        )
+        .description('List inference providers with health metrics')
         .option('--rpc <url>', '0G Chain RPC endpoint')
         .option('--ledger-ca <address>', 'Account (ledger) contract address')
         .option('--inference-ca <address>', 'Inference contract address')
@@ -469,7 +525,11 @@ export default function inference(program: Command) {
                         table.push([
                             'Models',
                             chalk.green(
-                                `multi-model${service.priceDenomination ? ` (${service.priceDenomination})` : ''}`
+                                `multi-model${
+                                    service.priceDenomination
+                                        ? ` (${service.priceDenomination})`
+                                        : ''
+                                }`
                             ) +
                                 `\nRun: 0g-compute-cli inference get-models --provider ${service.provider}`,
                         ])
@@ -482,25 +542,31 @@ export default function inference(program: Command) {
                         table.push(['Model Name', modelInfo.name])
                     }
                     if (modelInfo?.description) {
-                        const desc = modelInfo.description.length > 80
-                            ? modelInfo.description.slice(0, 77) + '...'
-                            : modelInfo.description
+                        const desc =
+                            modelInfo.description.length > 80
+                                ? modelInfo.description.slice(0, 77) + '...'
+                                : modelInfo.description
                         table.push(['Description', desc])
                     }
                     if (modelInfo?.context_length) {
                         table.push([
                             'Context Length',
-                            modelInfo.context_length.toLocaleString() + ' tokens',
+                            modelInfo.context_length.toLocaleString() +
+                                ' tokens',
                         ])
                     }
                     if (modelInfo?.max_completion_tokens) {
                         table.push([
                             'Max Completion Tokens',
-                            modelInfo.max_completion_tokens.toLocaleString() + ' tokens',
+                            modelInfo.max_completion_tokens.toLocaleString() +
+                                ' tokens',
                         ])
                     }
                     if (modelInfo?.architecture?.tokenizer) {
-                        table.push(['Tokenizer', modelInfo.architecture.tokenizer])
+                        table.push([
+                            'Tokenizer',
+                            modelInfo.architecture.tokenizer,
+                        ])
                     }
                     if (modelInfo?.owned_by) {
                         table.push(['Owned By', modelInfo.owned_by])
@@ -531,11 +597,14 @@ export default function inference(program: Command) {
                             'Price Per Second (0G)',
                             service.inputPrice
                                 ? neuronToA0gi(
-                                    BigInt(service.inputPrice)
-                                ).toFixed(18)
+                                      BigInt(service.inputPrice)
+                                  ).toFixed(18)
                                 : 'N/A',
                         ])
-                    } else if (service.priceDenomination === 'USD' && modelInfo?.pricing_usd) {
+                    } else if (
+                        service.priceDenomination === 'USD' &&
+                        modelInfo?.pricing_usd
+                    ) {
                         // USD-denominated provider: show USD prices (incl. tiered
                         // and cache) in one consolidated cell, consistent with
                         // `list-providers` (which flags "(USD)") and `get-models`.
@@ -565,8 +634,8 @@ export default function inference(program: Command) {
                                     'Input Price Per Token (0G)',
                                     service.inputPrice
                                         ? neuronToA0gi(
-                                            BigInt(service.inputPrice)
-                                        ).toFixed(18)
+                                              BigInt(service.inputPrice)
+                                          ).toFixed(18)
                                         : 'N/A',
                                 ])
                             }
@@ -579,27 +648,43 @@ export default function inference(program: Command) {
                                 outputPriceLabel,
                                 service.outputPrice
                                     ? neuronToA0gi(
-                                        BigInt(service.outputPrice)
-                                    ).toFixed(18)
+                                          BigInt(service.outputPrice)
+                                      ).toFixed(18)
                                     : 'N/A',
                             ])
 
                             // Show cache hit price for flat pricing (non-image services)
-                            if (service.cacheTokenBilling && !isImageService && service.inputPrice) {
+                            if (
+                                service.cacheTokenBilling &&
+                                !isImageService &&
+                                service.inputPrice
+                            ) {
                                 const cacheHitPrice = neuronToA0gi(
-                                    BigInt(service.inputPrice) / BigInt(service.cacheTokenBilling.divisor)
+                                    BigInt(service.inputPrice) /
+                                        BigInt(
+                                            service.cacheTokenBilling.divisor
+                                        )
                                 ).toFixed(18)
-                                table.push(['Cache Hit Price Per Token (0G)', cacheHitPrice])
+                                table.push([
+                                    'Cache Hit Price Per Token (0G)',
+                                    cacheHitPrice,
+                                ])
                             }
                         }
 
                         const pricingUSD = modelInfo?.pricing_usd
                         if (pricingUSD) {
                             if (!isImageService && pricingUSD.prompt) {
-                                table.push(['Input Price Per Token (USD)', pricingUSD.prompt])
+                                table.push([
+                                    'Input Price Per Token (USD)',
+                                    pricingUSD.prompt,
+                                ])
                             }
                             if (pricingUSD.image) {
-                                table.push(['Price Per Image (USD)', pricingUSD.image])
+                                table.push([
+                                    'Price Per Image (USD)',
+                                    pricingUSD.image,
+                                ])
                             } else if (pricingUSD.completion) {
                                 const usdLabel = isImageService
                                     ? 'Price Per Image (USD)'
@@ -631,8 +716,8 @@ export default function inference(program: Command) {
                                 health.uptime >= 85
                                     ? chalk.green(`${health.uptime}%`)
                                     : health.uptime >= 70
-                                        ? chalk.yellow(`${health.uptime}%`)
-                                        : chalk.red(`${health.uptime}%`)
+                                    ? chalk.yellow(`${health.uptime}%`)
+                                    : chalk.red(`${health.uptime}%`)
                             table.push(['Uptime', uptimeDisplay])
                         }
                     } else {
@@ -646,8 +731,8 @@ export default function inference(program: Command) {
                 console.log(
                     chalk.gray(
                         '\nNote: Health metrics are fetched from the monitoring API. ' +
-                        'Services without metrics may be newly registered or temporarily unavailable. ' +
-                        'Model details are fetched from the status API.'
+                            'Services without metrics may be newly registered or temporarily unavailable. ' +
+                            'Model details are fetched from the status API.'
                     )
                 )
             })
@@ -1106,7 +1191,7 @@ export default function inference(program: Command) {
                         console.error(
                             'Error:',
                             axiosError.response.data?.error ||
-                            axiosError.response.statusText
+                                axiosError.response.statusText
                         )
                     } else if (error instanceof Error) {
                         console.error('Error:', error.message)
@@ -1207,7 +1292,7 @@ export default function inference(program: Command) {
                         console.error(
                             'Error:',
                             axiosError.response.data?.error ||
-                            axiosError.response.statusText
+                                axiosError.response.statusText
                         )
                     } else if (error instanceof Error) {
                         console.error('Error:', error.message)
@@ -1297,7 +1382,8 @@ export default function inference(program: Command) {
                     }
 
                     console.log(
-                        `\n${chalk.blue('Log file:')} ${options.component}/${options.filename
+                        `\n${chalk.blue('Log file:')} ${options.component}/${
+                            options.filename
                         }`
                     )
                     console.log(`${chalk.blue('Provider:')} ${userAddress}`)
@@ -1322,7 +1408,7 @@ export default function inference(program: Command) {
                         console.error(
                             'Error:',
                             axiosError.response.data?.error ||
-                            axiosError.response.statusText
+                                axiosError.response.statusText
                         )
                     } else if (error instanceof Error) {
                         console.error('Error:', error.message)

--- a/src.ts/sdk/inference/broker/__tests__/tiered-pricing.test.ts
+++ b/src.ts/sdk/inference/broker/__tests__/tiered-pricing.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import {
+    parseTieredPricing,
+    parseTieredPricingFromModelInfo,
+    ProviderModelInfo,
+} from '../read-only-model'
+
+describe('tiered pricing multiplier fold', () => {
+    it('folds num/den into an effective decimal (HTTP /v1/models)', () => {
+        const modelInfo = {
+            pricing: {
+                tiered_pricing: [
+                    {
+                        max_input_tokens: 32000,
+                        input_multiplier: 1,
+                        output_multiplier: 1,
+                    },
+                    {
+                        max_input_tokens: 0,
+                        input_multiplier: 3,
+                        input_multiplier_denominator: 2, // 1.5x
+                        output_multiplier: 5,
+                        output_multiplier_denominator: 2, // 2.5x
+                    },
+                ],
+            },
+        } as unknown as ProviderModelInfo
+
+        const parsed = parseTieredPricingFromModelInfo(modelInfo)
+        expect(parsed?.tiers).to.have.length(2)
+        expect(parsed!.tiers[0].inputMultiplier).to.equal(1)
+        expect(parsed!.tiers[1].inputMultiplier).to.equal(1.5)
+        expect(parsed!.tiers[1].outputMultiplier).to.equal(2.5)
+    })
+
+    it('treats a missing denominator as 1 (legacy integer config unchanged)', () => {
+        const modelInfo = {
+            pricing: {
+                tiered_pricing: [
+                    {
+                        max_input_tokens: 0,
+                        input_multiplier: 4,
+                        output_multiplier: 3,
+                    },
+                ],
+            },
+        } as unknown as ProviderModelInfo
+
+        const parsed = parseTieredPricingFromModelInfo(modelInfo)
+        expect(parsed!.tiers[0].inputMultiplier).to.equal(4)
+        expect(parsed!.tiers[0].outputMultiplier).to.equal(3)
+    })
+
+    it('folds num/den from on-chain additionalInfo', () => {
+        const additionalInfo = JSON.stringify({
+            tieredPricing: {
+                tiers: [
+                    {
+                        maxInputTokens: 0,
+                        inputMultiplier: 3,
+                        inputMultiplierDenominator: 2,
+                        outputMultiplier: 2,
+                        // outputMultiplierDenominator omitted -> 1
+                    },
+                ],
+            },
+        })
+
+        const parsed = parseTieredPricing(additionalInfo)
+        expect(parsed!.tiers[0].inputMultiplier).to.equal(1.5)
+        expect(parsed!.tiers[0].outputMultiplier).to.equal(2)
+    })
+})

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -51,9 +51,7 @@ function attachModelHealth(
     for (const model of models) {
         let health =
             byModel.get(model.id) ??
-            (model.canonical_id
-                ? byModel.get(model.canonical_id)
-                : undefined)
+            (model.canonical_id ? byModel.get(model.canonical_id) : undefined)
         if (!health && models.length === 1 && forProvider.length === 1) {
             health = forProvider[0]
         }
@@ -142,6 +140,11 @@ export interface ProviderModelInfo {
             max_input_tokens: number
             input_multiplier: number
             output_multiplier: number
+            /** Multiplier denominators. The effective multiplier is the
+             * numerator over the denominator (e.g. 3 / 2 = 1.5x). Omitted by the
+             * broker when 1 (integer multiple); treat a missing value as 1. */
+            input_multiplier_denominator?: number
+            output_multiplier_denominator?: number
         }>
         /** Cache token billing configuration */
         cache_token_billing?: {
@@ -166,6 +169,11 @@ export interface ProviderModelInfo {
             max_input_tokens: number
             input_multiplier: number
             output_multiplier: number
+            /** Multiplier denominators. The effective multiplier is the
+             * numerator over the denominator (e.g. 3 / 2 = 1.5x). Omitted by the
+             * broker when 1 (integer multiple); treat a missing value as 1. */
+            input_multiplier_denominator?: number
+            output_multiplier_denominator?: number
         }>
         /** Cache token billing configuration */
         cache_token_billing?: {
@@ -196,11 +204,26 @@ export interface ProviderModelInfo {
  * A single pricing tier for input-length-based tiered pricing.
  * Tiers are ordered by maxInputTokens ascending.
  * maxInputTokens: 0 means unlimited (the highest tier).
+ *
+ * inputMultiplier/outputMultiplier are the EFFECTIVE multipliers: the broker may
+ * express a tier as a numerator/denominator fraction (e.g. 3/2 = 1.5x), which the
+ * parsers below fold into a single decimal here (1.5). Consumers multiply the base
+ * price by this value directly — no denominator handling needed downstream.
  */
 export interface PricingTier {
     maxInputTokens: number
     inputMultiplier: number
     outputMultiplier: number
+}
+
+/**
+ * Fold a broker multiplier numerator/denominator pair into a single effective
+ * decimal multiplier. A missing/zero/negative denominator means 1 (the broker
+ * omits the denominator for integer multiples), so legacy integer configs are
+ * unchanged.
+ */
+function effectiveMultiplier(numerator: number, denominator?: number): number {
+    return denominator && denominator > 0 ? numerator / denominator : numerator
 }
 
 /**
@@ -232,8 +255,14 @@ export function parseTieredPricing(
                 )
                 .map((t: any) => ({
                     maxInputTokens: t.maxInputTokens,
-                    inputMultiplier: t.inputMultiplier,
-                    outputMultiplier: t.outputMultiplier,
+                    inputMultiplier: effectiveMultiplier(
+                        t.inputMultiplier,
+                        t.inputMultiplierDenominator
+                    ),
+                    outputMultiplier: effectiveMultiplier(
+                        t.outputMultiplier,
+                        t.outputMultiplierDenominator
+                    ),
                 }))
             if (tiers.length > 0) {
                 return { tiers }
@@ -265,8 +294,14 @@ export function parseTieredPricingFromModelInfo(
         )
         .map((t) => ({
             maxInputTokens: t.max_input_tokens,
-            inputMultiplier: t.input_multiplier,
-            outputMultiplier: t.output_multiplier,
+            inputMultiplier: effectiveMultiplier(
+                t.input_multiplier,
+                t.input_multiplier_denominator
+            ),
+            outputMultiplier: effectiveMultiplier(
+                t.output_multiplier,
+                t.output_multiplier_denominator
+            ),
         }))
     if (tiers.length > 0) {
         return { tiers }
@@ -560,12 +595,13 @@ export class ReadOnlyModelProcessor {
                         teeSignerAcknowledged: service.teeSignerAcknowledged,
                         healthMetrics: health
                             ? {
-                                status: health.status,
-                                uptime: health.checks.uptime,
-                                avgResponseTime:
-                                    health.performance.response_time?.avg ?? 0,
-                                lastCheck: health.lastCheck,
-                            }
+                                  status: health.status,
+                                  uptime: health.checks.uptime,
+                                  avgResponseTime:
+                                      health.performance.response_time?.avg ??
+                                      0,
+                                  lastCheck: health.lastCheck,
+                              }
                             : undefined,
                         modelInfo,
                         tieredPricing:

--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -222,7 +222,10 @@ export interface PricingTier {
  * omits the denominator for integer multiples), so legacy integer configs are
  * unchanged.
  */
-function effectiveMultiplier(numerator: number, denominator?: number): number {
+export function effectiveMultiplier(
+    numerator: number,
+    denominator?: number
+): number {
     return denominator && denominator > 0 ? numerator / denominator : numerator
 }
 

--- a/src.ts/sdk/inference/index.ts
+++ b/src.ts/sdk/inference/index.ts
@@ -30,4 +30,5 @@ export {
     parseTieredPricing,
     parseCacheTokenBilling,
     parseMultiModelInfo,
+    effectiveMultiplier,
 } from './broker'


### PR DESCRIPTION
## Why

The broker now expresses tier price multipliers as a **num/den fraction** (e.g. 3/2 = 1.5x) via new `*_multiplier_denominator` fields on `tiered_pricing`. The SDK read only the numerator and multiplied the base price by it, so a fractional tier would display **3x instead of 1.5x** (inflated price). Parsing is lenient (unknown fields ignored), so this was a wrong-*display* bug, not a crash.

Companion to 0g-serving-broker#598 (producer) and 0g-router#601 (billing).

## What

Fold `num/den` into a single **effective decimal** at the two parse boundaries — `parseTieredPricingFromModelInfo` (HTTP `/v1/models`) and `parseTieredPricing` (on-chain `additionalInfo`) — via `effectiveMultiplier()`. The normalized `PricingTier.inputMultiplier` is already a JS `number` and every downstream consumer (CLI, web-ui) multiplies `base × it`, so folding to e.g. `1.5` makes all of them correct **with no display-code changes**.

Backward compatible: a missing/zero denominator = 1, so existing integer-only configs are unchanged.

## Rollout ⚠️

This is a **display consumer** — deploy it (and the router) before the broker emits any fractional config. See 0g-serving-broker#598. No-op until a fractional config exists.

## Tests

New `tiered-pricing.test.ts`: fold (HTTP), missing-denominator=1 (legacy unchanged), on-chain fold. `tsc` typecheck + SDK build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)