### PR TITLE
chore: release v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0gfoundation/0g-compute-ts-sdk",
-    "version": "0.9.0-beta.0",
+    "version": "0.9.0",
     "description": "TS SDK for 0G Compute Network",
     "main": "./lib.commonjs/index.js",
     "bin": {


### PR DESCRIPTION
Bump `package.json` to `0.9.0`, promoting the `0.9.0-beta.0` line to stable.

Contents of 0.9.0 over the last stable (0.8.4):
- multi-model provider support — list / get-models / select (#220)
- fractional tier price multipliers — num/den, folded to an effective decimal in the tiered-pricing parsers (#225)

Publishing 0.9.0 to npm `latest` is what lets customers pick up the fractional-multiplier fix via `npm install` (0.8.4 does not have it; beta versions don't land on `latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)