### PR TITLE
feat(inference): surface per-model provider_identity/serving_domain in model type

### DIFF
--- a/src.ts/sdk/inference/broker/read-only-model.ts
+++ b/src.ts/sdk/inference/broker/read-only-model.ts
@@ -187,6 +187,23 @@ export interface ProviderModelInfo {
     tee_type?: string
     tee_verifier?: string
     /**
+     * Machine key of the upstream that actually serves THIS model, published
+     * per-model by the broker. When one provider (one serving URL) fronts several
+     * upstreams (e.g. `aliyun` for one model and `minimax` for another), this
+     * distinguishes them per model rather than reporting one provider-level
+     * identity. Centralized providers only; omitted when the broker does not
+     * publish it. Informational — verification of a response is unaffected (it
+     * recovers the broker TEE signer, which is constant per provider).
+     */
+    provider_identity?: string
+    /**
+     * Hostname of the upstream serving THIS model (e.g. `dashscope.aliyuncs.com`),
+     * published per-model by the broker. Descriptive/display only; per-model so a
+     * multi-upstream provider reports the real host for each model. Omitted when
+     * the broker does not publish it.
+     */
+    serving_domain?: string
+    /**
      * Per-model health/uptime metrics merged from the status API `/health`
      * endpoint (NOT part of the raw /v1/models payload). Populated by
      * {@link ReadOnlyModelProcessor.getProviderModels} and


### PR DESCRIPTION
## What & why

Companion to the broker/router change that lets **one provider proxy multiple upstream LLM hosts** (e.g. Bailian + Minimax under one serving URL). The broker now publishes `provider_identity` and `serving_domain` **per model** in `/v1/models`. This adds both as optional fields on `ProviderModelInfo` so SDK consumers can see which upstream serves each model of a multi-upstream provider.

## Change
- `read-only-model.ts`: add optional `provider_identity?` and `serving_domain?` to `ProviderModelInfo`.

## Compatibility
Purely additive and backward compatible:
- Both fields are optional.
- The `/v1/models` `data` array is already assigned straight through to `ProviderModelInfo[]`, so the fields flow at runtime today — this only adds the **types** so consumers can read them safely.
- **No verification logic changes.** Response verification still recovers the broker TEE signer (constant per provider), and never parses/enum-checks `provider_identity`/`serving_domain` — so per-model identity is invisible to the trust path. Verified: the SDK needs no functional change for multi-upstream to work; this PR is the ergonomics/visibility half.

## Verification
`tsc -p tsconfig.commonjs.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)