### PR TITLE
feat(cli): show Upstream (provider_identity) column in get-models

### DIFF
--- a/src.ts/cli/inference.ts
+++ b/src.ts/cli/inference.ts
@@ -472,13 +472,20 @@ export default function inference(program: Command) {
                 const useUsd = result.priceDenomination === 'USD'
                 const priceUnit = useUsd ? 'USD' : '0G'
                 const table = new Table({
-                    head: ['Model', 'Type', `Pricing (${priceUnit})`, 'Health'],
-                    colWidths: [24, 10, 44, 20],
+                    head: [
+                        'Model',
+                        'Upstream',
+                        'Type',
+                        `Pricing (${priceUnit})`,
+                        'Health',
+                    ],
+                    colWidths: [22, 12, 8, 40, 18],
                     wordWrap: true,
                 })
                 for (const m of result.models) {
                     table.push([
                         m.id,
+                        m.provider_identity || '-',
                         m.type ?? '-',
                         formatModelPricing(m, useUsd),
                         formatModelHealth(m.healthMetrics),


### PR DESCRIPTION
## What / Why
Adds an **Upstream** column (from `provider_identity`) between Model and Type in the `get-models` command's table. A provider serving the **same** model id via two upstreams (e.g. `glm-5.2` via `aliyun` and `zhipu`) now shows distinguishable rows instead of identical-looking duplicates.

## Backward-compat
- Legacy models with no `provider_identity` show `-`.
- Single-upstream providers still get one row per model, just with a `-` in the new column.
- No other behavior change; `list-providers` and other commands untouched.

## Not a break
This is a human-facing terminal table, not a programmatic API — adding a column doesn't break consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)